### PR TITLE
[TEST] Add CLI tests for find_deletions.

### DIFF
--- a/test/cli/CMakeLists.txt
+++ b/test/cli/CMakeLists.txt
@@ -3,5 +3,9 @@ cmake_minimum_required (VERSION 3.8)
 add_cli_test (fastq_to_fasta_options_test.cpp)
 target_use_datasources (fastq_to_fasta_options_test FILES in.fastq)
 
+add_cli_test(find_deletions_cli_test.cpp)
+add_dependencies (find_deletions_cli_test "find_deletions")
+target_use_datasources (find_deletions_cli_test FILES detect_breakends_shorted.vcf)
+
 # add_cli_test (iGenVar_options_test.cpp)
 # target_use_datasources (iGenVar_options_test FILES in.fastq)

--- a/test/cli/find_deletions_cli_test.cpp
+++ b/test/cli/find_deletions_cli_test.cpp
@@ -1,0 +1,48 @@
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/io/sequence_file/input.hpp>
+
+#include "cli_test.hpp"
+
+TEST_F(cli_test, no_options)
+{
+    cli_test_result result = execute_app("find_deletions");
+    std::string expected
+    {
+            "partitionJunctions - Find deletions\n"
+            "===================================\n"
+            "    Try -h or --help for more information.\n"
+    };
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_EQ(result.out, expected);
+    EXPECT_EQ(result.err, std::string{});
+}
+
+TEST_F(cli_test, fail_no_argument)
+{
+    cli_test_result result = execute_app("find_deletions", "-v");
+    std::string expected
+    {
+        "[Error] Unknown option -v. In case this is meant to be a non-option/argument/parameter, please specify "
+        "the start of non-options with '--'. See -h/--help for program information.\n"
+    };
+    EXPECT_NE(result.exit_code, 0);
+    EXPECT_EQ(result.out, std::string{});
+    EXPECT_EQ(result.err, expected);
+}
+
+TEST_F(cli_test, with_arguments)
+{
+    cli_test_result result = execute_app("find_deletions",
+                                         data("detect_breakends_shorted.vcf"));
+    std::string expected
+    {
+        "##fileformat=VCFv4.2\n"
+        "##source=iGenVarCaller\n"
+        "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-50;END=9435286\n"
+        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-248;END=11104822\n"
+    };
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_EQ(result.out, expected);
+    EXPECT_EQ(result.err, std::string{});
+}


### PR DESCRIPTION
Inspired by the other CLI tests. Probably won't build, because no `make` is called before `ctest` or `make test`.