### PR TITLE
Add overload function for output to std::cout. Remove mandatory requi…

### DIFF
--- a/include/find_deletions/deletion_finding_and_printing.hpp
+++ b/include/find_deletions/deletion_finding_and_printing.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <seqan3/std/filesystem>
+#include <seqan3/io/stream/concept.hpp>
 #include <fstream>
+#include <iostream>
 #include <vector>
 
 #include "junction.hpp"
@@ -14,3 +16,6 @@
  * \details Extracts deletions out of given breakends / junctions.
  */
 void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::filesystem::path const & output_file_path);
+
+//!\overload
+void find_and_print_deletions(std::filesystem::path const & junction_file_path);

--- a/include/find_deletions/deletion_finding_and_printing.hpp
+++ b/include/find_deletions/deletion_finding_and_printing.hpp
@@ -18,4 +18,5 @@
 void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::ostream & out_stream);
 
 //!\overload
-void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::filesystem::path const & output_file_path);
+void find_and_print_deletions(std::filesystem::path const & junction_file_path,
+                              std::filesystem::path const & output_file_path);

--- a/include/find_deletions/deletion_finding_and_printing.hpp
+++ b/include/find_deletions/deletion_finding_and_printing.hpp
@@ -11,11 +11,11 @@
 /*! \brief Detects deletions out of the junction file.
  *
  * \param junction_file_path input junction file
- * \param output_file_path output vcf file
+ * \param out_stream output stream
  *
  * \details Extracts deletions out of given breakends / junctions.
  */
-void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::filesystem::path const & output_file_path);
+void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::ostream & out_stream);
 
 //!\overload
-void find_and_print_deletions(std::filesystem::path const & junction_file_path);
+void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::filesystem::path const & output_file_path);

--- a/src/find_deletions.cpp
+++ b/src/find_deletions.cpp
@@ -15,7 +15,8 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.version = "0.0.1";
     parser.add_option(args.junction_file_path, 'i', "input", "Input junctions tab-separated format.",
                       seqan3::option_spec::REQUIRED);
-    parser.add_option(args.output_file_path, 'o', "output", "The path of the vcf output file. If no path is given, will output to standard output.");
+    parser.add_option(args.output_file_path, 'o', "output",
+                      "The path of the vcf output file. If no path is given, will output to standard output.");
 }
 
 int main(int argc, char ** argv)

--- a/src/find_deletions.cpp
+++ b/src/find_deletions.cpp
@@ -32,14 +32,7 @@ int main(int argc, char ** argv)
         seqan3::debug_stream << "[Error] " << ext.what() << "\n";       // customise your error message
         return -1;
     }
-    if (!args.output_file_path.empty())
-    {
-        find_and_print_deletions(args.junction_file_path, args.output_file_path);
-    }
-    else
-    {
-        find_and_print_deletions(args.junction_file_path);
-    }
+    find_and_print_deletions(args.junction_file_path, args.output_file_path);
 
 
     return 0;

--- a/src/find_deletions.cpp
+++ b/src/find_deletions.cpp
@@ -15,8 +15,7 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.version = "0.0.1";
     parser.add_option(args.junction_file_path, 'i', "input", "Input junctions tab-separated format.",
                       seqan3::option_spec::REQUIRED);
-    parser.add_option(args.output_file_path, 'o', "output", "The path of the vcf output file.",
-                      seqan3::option_spec::REQUIRED );
+    parser.add_option(args.output_file_path, 'o', "output", "The path of the vcf output file. If no path is given, will output to standard output.");
 }
 
 int main(int argc, char ** argv)
@@ -33,7 +32,14 @@ int main(int argc, char ** argv)
         seqan3::debug_stream << "[Error] " << ext.what() << "\n";       // customise your error message
         return -1;
     }
-    find_and_print_deletions(args.junction_file_path, args.output_file_path);
+    if (!args.output_file_path.empty())
+    {
+        find_and_print_deletions(args.junction_file_path, args.output_file_path);
+    }
+    else
+    {
+        find_and_print_deletions(args.junction_file_path);
+    }
 
 
     return 0;

--- a/src/find_deletions/deletion_finding_and_printing.cpp
+++ b/src/find_deletions/deletion_finding_and_printing.cpp
@@ -118,7 +118,8 @@ void print_deletion(std::string chrom, int32_t start, int32_t end, int32_t qual,
  }
 
 //!\overload
-void find_and_print_deletions(std::filesystem::path const & junction_file_path, std::filesystem::path const & output_file_path)
+void find_and_print_deletions(std::filesystem::path const & junction_file_path,
+                              std::filesystem::path const & output_file_path)
 {
     if (output_file_path.empty())
     {

--- a/src/find_deletions/deletion_finding_and_printing.cpp
+++ b/src/find_deletions/deletion_finding_and_printing.cpp
@@ -41,7 +41,7 @@ std::vector<junction> read_junctions(std::filesystem::path const & junction_file
 
 /*! \brief Prints the header of a vcf file to a given outputfile.
  *
- * \param out_stream ouput stream object
+ * \param out_stream output stream object
  */
 void print_vcf_header(std::ostream & out_stream)
 {

--- a/test/api/deletion_finding_and_printing_test.cpp
+++ b/test/api/deletion_finding_and_printing_test.cpp
@@ -28,7 +28,7 @@ TEST(group1, test_out_file)
 TEST(group1, test_std_out)
 {
     testing::internal::CaptureStdout();
-    find_and_print_deletions(DATADIR"detect_breakends_shorted.vcf");
+    find_and_print_deletions(DATADIR"detect_breakends_shorted.vcf", "");
     std::string std_cout = testing::internal::GetCapturedStdout();
     std::string expected
     {

--- a/test/api/deletion_finding_and_printing_test.cpp
+++ b/test/api/deletion_finding_and_printing_test.cpp
@@ -6,8 +6,8 @@
 
 #include "find_deletions/deletion_finding_and_printing.hpp"
 
-TEST(group1, test_std_out)
-{   
+TEST(group1, test_out_file)
+{
     find_and_print_deletions(DATADIR"detect_breakends_shorted.vcf", DATADIR"find_deletions_file_out_test.vcf");
     std::ifstream f;
     f.open(DATADIR"find_deletions_file_out_test.vcf");
@@ -23,4 +23,20 @@ TEST(group1, test_std_out)
     };
     EXPECT_TRUE(f.is_open());
     EXPECT_EQ(buffer.str(), expected);
+}
+
+TEST(group1, test_std_out)
+{
+    testing::internal::CaptureStdout();
+    find_and_print_deletions(DATADIR"detect_breakends_shorted.vcf");
+    std::string std_cout = testing::internal::GetCapturedStdout();
+    std::string expected
+    {
+        "##fileformat=VCFv4.2\n"
+        "##source=iGenVarCaller\n"
+        "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-50;END=9435286\n"
+        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-248;END=11104822\n"
+    };
+    EXPECT_EQ(std_cout, expected);
 }

--- a/test/cli/find_deletions_cli_test.cpp
+++ b/test/cli/find_deletions_cli_test.cpp
@@ -33,14 +33,17 @@ TEST_F(cli_test, with_one_argument)
 {
     cli_test_result result = execute_app("find_deletions",
                                          "-i", data("detect_breakends_shorted.vcf"));
-    
-    std::string err
+    std::string expected
     {
-        "[Error] Option -o/--output is required but not set.\n"
+        "##fileformat=VCFv4.2\n##source=iGenVarCaller\n"
+        "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-50;END=9435286\n"
+        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-248;END=11104822\n"
     };
-    EXPECT_EQ(result.exit_code, 65280);
-    EXPECT_EQ(result.out, std::string{});
-    EXPECT_EQ(result.err, err);
+
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_EQ(result.out, expected);
+    EXPECT_EQ(result.err, std::string{});
 }
 
 TEST_F(cli_test, with_arguments)
@@ -48,7 +51,7 @@ TEST_F(cli_test, with_arguments)
     cli_test_result result = execute_app("find_deletions",
                                          "-i", data("detect_breakends_shorted.vcf"),
                                          "-o", "find_deletions_file_out_test.vcf");
-    
+
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});


### PR DESCRIPTION
…rement for output file option. Add testing.

Resolves #38. Output file is no longer a mandatory option. If called without an output file given, will output to std::cout by default.

Note: I didn't do this very efficiently... Created an overload function which resulted in a bit of code duplication, but I couldn't think of a clever way to allow passing a filesystem path OR std::cout without opening the ostream in main.cpp.