### PR TITLE
Add a skeleton VCF parser which can print variants in VCF output.

### DIFF
--- a/include/variant_parser/variant_record.hpp
+++ b/include/variant_parser/variant_record.hpp
@@ -34,7 +34,7 @@ public:
 
     /*! \brief Set the file format for this VCF file header.
      *
-     *  \param fileformati The input fileformat.
+     *  \param fileformat_i The input fileformat.
      */
     void set_fileformat(std::string fileformat_i)
     {
@@ -43,12 +43,12 @@ public:
 
     /*! \brief Add header information for a given INFO field.
      *
-     *  \param info_keyi The INFO key name.
-     *  \param numberi The number of values this key can hold.
-     *  \param typei The type of values this key holds.
-     *  \param descriptioni The description of this INFO field..
-     *  \param sourcei The source of the INFO field.
-     *  \param versioni The version of the source.
+     *  \param info_key_i The INFO key name.
+     *  \param number_i The number of values this key can hold.
+     *  \param type_i The type of values this key holds.
+     *  \param description_i The description of this INFO field..
+     *  \param source_i The source of the INFO field.
+     *  \param version_i The version of the source.
      */
     void add_meta_info(std::string info_key_i, std::uint8_t number_i, std::string type_i, std::string description_i,
                        std::string source_i, std::string version_i)
@@ -97,7 +97,7 @@ public:
 
     /*! \brief Set the chromosome for a variant.
      *
-     * \param chromi The chromosome value to use.
+     * \param chrom_i The chromosome value to use.
      */
     void set_chrom(std::string chrom_i)
     {
@@ -106,7 +106,7 @@ public:
 
     /*! \brief Set the pos for a variant.
      *
-     * \param posi The pos value to use.
+     * \param pos_i The pos value to use.
      */
     void set_pos(std::uint64_t pos_i)
     {
@@ -115,7 +115,7 @@ public:
 
     /*! \brief Set the id for a variant.
      *
-     * \param idi The id value to use.
+     * \param id_i The id value to use.
      */
     void set_id(std::string id_i)
     {
@@ -124,7 +124,7 @@ public:
 
     /*! \brief Set the ref for a variant.
      *
-     * \param refi The ref value to use.
+     * \param ref_i The ref value to use.
      */
     void set_ref(std::string ref_i)
     {
@@ -133,7 +133,7 @@ public:
 
     /*! \brief Set the alt for a variant.
      *
-     * \param alti The alt value to use.
+     * \param alt_i The alt value to use.
      */
     void set_alt(std::string alt_i)
     {
@@ -142,7 +142,7 @@ public:
 
     /*! \brief Set the qual for a variant.
      *
-     * \param quali The qual value to use.
+     * \param qual_i The qual value to use.
      */
     void set_qual(float qual_i)
     {
@@ -151,7 +151,7 @@ public:
 
     /*! \brief Set the filter for a variant.
      *
-     * \param filteri The filter value to use.
+     * \param filter_i The filter value to use.
      */
     void set_filter(std::string filter_i)
     {

--- a/include/variant_parser/variant_record.hpp
+++ b/include/variant_parser/variant_record.hpp
@@ -2,11 +2,18 @@
 #include <fstream>
 #include <map>
 
+/*
+ * An info field looks as follows:
+ * ##INFO=<ID=ID,Number=number,Type=type,Description="description",Source="source",Version="version">
+ * https://samtools.github.io/hts-specs/VCFv4.3.pdf (1.4.2 Information field format)
+ */
 class info_entry
 {
 public:
-    info_entry(std::string keyi, std::uint8_t numberi, std::string typei, std::string descriptioni, std::string sourcei, std::string versioni) :
-        key{std::move(keyi)}, number{numberi}, type{std::move(typei)}, description{std::move(descriptioni)}, source{std::move(sourcei)}, version{std::move(versioni)}
+    info_entry(std::string key_i, std::uint8_t number_i, std::string type_i, std::string description_i,
+               std::string source_i, std::string version_i) :
+        key{std::move(key_i)}, number{number_i}, type{std::move(type_i)}, description{std::move(description_i)},
+            source{std::move(source_i)}, version{std::move(version_i)}
     {}
     std::string key{};
     std::uint8_t number{};
@@ -16,6 +23,10 @@ public:
     std::string version{};
 };
 
+/*
+ * The variant header stores information about each of the keys of the info field along with other miscellaneous
+ * information, including current VCF file format and the source of the generated file.
+ */
 class variant_header
 {
 public:
@@ -25,9 +36,9 @@ public:
      *
      *  \param fileformati The input fileformat.
      */
-    void set_fileformat(std::string fileformati)
+    void set_fileformat(std::string fileformat_i)
     {
-        fileformat = fileformati;
+        fileformat = fileformat_i;
     }
 
     /*! \brief Add header information for a given INFO field.
@@ -39,9 +50,10 @@ public:
      *  \param sourcei The source of the INFO field.
      *  \param versioni The version of the source.
      */
-    void add_meta_info(std::string info_keyi, std::uint8_t numberi, std::string typei, std::string descriptioni, std::string sourcei, std::string versioni)
+    void add_meta_info(std::string info_key_i, std::uint8_t number_i, std::string type_i, std::string description_i,
+                       std::string source_i, std::string version_i)
     {
-        info.push_back(info_entry{info_keyi, numberi, typei, descriptioni, sourcei, versioni});
+        info.push_back(info_entry{info_key_i, number_i, type_i, description_i, source_i, version_i});
     }
 
     /*! \brief Prints the VCF header to a given output.
@@ -60,7 +72,9 @@ public:
         out_stream << "##source=" << source << '\n';
         for (const auto& i : info)
         {
-            out_stream << "##INFO=<ID=" << i.key << ",Number=" << std::to_string(i.number) << ",Type=" << i.type << ",Description=\"" << i.description << "\",Source=\"" << i.source << "\",Version=\"" << i.version << "\">" << '\n';
+            out_stream << "##INFO=<ID=" << i.key << ",Number=" << std::to_string(i.number) << ",Type=" << i.type
+                       << ",Description=\"" << i.description << "\",Source=\"" << i.source << "\",Version=\""
+                       << i.version << "\">" << '\n';
         }
         out_stream << "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" << '\n';
     }
@@ -71,6 +85,11 @@ private:
     std::vector<info_entry> info{};
 };
 
+/*
+ * A variant record consists of positional information, genotype information, and optional additional information in the
+ * INFO field.
+ */
+
 class variant_record
 {
 public:
@@ -80,63 +99,63 @@ public:
      *
      * \param chromi The chromosome value to use.
      */
-    void set_chrom(std::string chromi)
+    void set_chrom(std::string chrom_i)
     {
-        chrom = chromi;
+        chrom = chrom_i;
     }
 
     /*! \brief Set the pos for a variant.
      *
      * \param posi The pos value to use.
      */
-    void set_pos(std::uint64_t posi)
+    void set_pos(std::uint64_t pos_i)
     {
-        pos = posi;
+        pos = pos_i;
     }
 
     /*! \brief Set the id for a variant.
      *
      * \param idi The id value to use.
      */
-    void set_id(std::string idi)
+    void set_id(std::string id_i)
     {
-        id = idi;
+        id = id_i;
     }
 
     /*! \brief Set the ref for a variant.
      *
      * \param refi The ref value to use.
      */
-    void set_ref(std::string refi)
+    void set_ref(std::string ref_i)
     {
-        ref = refi;
+        ref = ref_i;
     }
 
     /*! \brief Set the alt for a variant.
      *
      * \param alti The alt value to use.
      */
-    void set_alt(std::string alti)
+    void set_alt(std::string alt_i)
     {
-        alt = alti;
+        alt = alt_i;
     }
 
     /*! \brief Set the qual for a variant.
      *
      * \param quali The qual value to use.
      */
-    void set_qual(float quali)
+    void set_qual(float qual_i)
     {
-        qual = quali;
+        qual = qual_i;
     }
 
     /*! \brief Set the filter for a variant.
      *
      * \param filteri The filter value to use.
      */
-    void set_filter(std::string filteri)
+    void set_filter(std::string filter_i)
     {
-        filter = filteri;
+        filter = filter_i;
     }
 
     /*! \brief Add an INFO entry for a variant.

--- a/include/variant_parser/variant_record.hpp
+++ b/include/variant_parser/variant_record.hpp
@@ -1,0 +1,193 @@
+#include <seqan3/io/stream/concept.hpp>
+#include <fstream>
+#include <map>
+
+class info_entry
+{
+public:
+    info_entry(std::string keyi, std::uint8_t numberi, std::string typei, std::string descriptioni, std::string sourcei, std::string versioni) :
+        key{std::move(keyi)}, number{numberi}, type{std::move(typei)}, description{std::move(descriptioni)}, source{std::move(sourcei)}, version{std::move(versioni)}
+    {}
+    std::string key{};
+    std::uint8_t number{};
+    std::string type{};
+    std::string description{};
+    std::string source{};
+    std::string version{};
+};
+
+class variant_header
+{
+public:
+    variant_header() {}
+
+    /*! \brief Set the file format for this VCF file header.
+     *
+     *  \param fileformati The input fileformat.
+     */
+    void set_fileformat(std::string fileformati)
+    {
+        fileformat = fileformati;
+    }
+
+    /*! \brief Add header information for a given INFO field.
+     *
+     *  \param info_keyi The INFO key name.
+     *  \param numberi The number of values this key can hold.
+     *  \param typei The type of values this key holds.
+     *  \param descriptioni The description of this INFO field..
+     *  \param sourcei The source of the INFO field.
+     *  \param versioni The version of the source.
+     */
+    void add_meta_info(std::string info_keyi, std::uint8_t numberi, std::string typei, std::string descriptioni, std::string sourcei, std::string versioni)
+    {
+        info.push_back(info_entry{info_keyi, numberi, typei, descriptioni, sourcei, versioni});
+    }
+
+    /*! \brief Prints the VCF header to a given output.
+     *
+     * \tparam stream_type A stream to print the output to.
+     *
+     * \param out_stream The output stream to print to.
+     */
+    template<typename stream_type>
+    //!cond
+        requires seqan3::output_stream<stream_type>
+    //!endcond
+    void print(stream_type & out_stream)
+    {
+        out_stream << "##fileformat=" << fileformat << '\n';
+        out_stream << "##source=" << source << '\n';
+        for (const auto& i : info)
+        {
+            out_stream << "##INFO=<ID=" << i.key << ",Number=" << std::to_string(i.number) << ",Type=" << i.type << ",Description=\"" << i.description << "\",Source=\"" << i.source << "\",Version=\"" << i.version << "\">" << '\n';
+        }
+        out_stream << "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" << '\n';
+    }
+
+private:
+    std::string fileformat{"VCFv4.3"};
+    std::string source{"iGenVarCaller"};
+    std::vector<info_entry> info{};
+};
+
+class variant_record
+{
+public:
+    variant_record() {}
+
+    /*! \brief Set the chromosome for a variant.
+     *
+     * \param chromi The chromosome value to use.
+     */
+    void set_chrom(std::string chromi)
+    {
+        chrom = chromi;
+    }
+
+    /*! \brief Set the pos for a variant.
+     *
+     * \param posi The pos value to use.
+     */
+    void set_pos(std::uint64_t posi)
+    {
+        pos = posi;
+    }
+
+    /*! \brief Set the id for a variant.
+     *
+     * \param idi The id value to use.
+     */
+    void set_id(std::string idi)
+    {
+        id = idi;
+    }
+
+    /*! \brief Set the ref for a variant.
+     *
+     * \param refi The ref value to use.
+     */
+    void set_ref(std::string refi)
+    {
+        ref = refi;
+    }
+
+    /*! \brief Set the alt for a variant.
+     *
+     * \param alti The alt value to use.
+     */
+    void set_alt(std::string alti)
+    {
+        alt = alti;
+    }
+
+    /*! \brief Set the qual for a variant.
+     *
+     * \param quali The qual value to use.
+     */
+    void set_qual(float quali)
+    {
+        qual = quali;
+    }
+
+    /*! \brief Set the filter for a variant.
+     *
+     * \param filteri The filter value to use.
+     */
+    void set_filter(std::string filteri)
+    {
+        filter = filteri;
+    }
+
+    /*! \brief Add an INFO entry for a variant.
+     *
+     * \param info_key The INFO key to use.
+     * \param info_value The INFO value to set.
+     */
+    void add_info(std::string info_key, std::string info_value)
+    {
+        info.insert_or_assign(info_key, info_value);
+    }
+
+    /*! \brief Prints the variant to a given output in VCF format.
+     *
+     * \tparam stream_type A stream to print the output to.
+     *
+     * \param out_stream The output stream to print to.
+     */
+    template<typename stream_type>
+    //!cond
+        requires seqan3::output_stream<stream_type>
+    //!endcond
+    void print(stream_type & out_stream)
+    {
+        std::map<std::string, std::string>::iterator last{};
+        out_stream << chrom << '\t';
+        out_stream << pos << '\t';
+        out_stream << id << '\t';
+        out_stream << ref << '\t';
+        out_stream << alt << '\t';
+        out_stream << qual << '\t';
+        out_stream << filter << '\t';
+        for (std::map<std::string, std::string>::iterator it = info.begin(); it != info.end(); ++it)
+        {
+            if (std::next(it) == info.end())
+            {
+                last = it;
+                break;
+            }
+            out_stream << (*it).first << "=" << (*it).second << ";";
+        }
+        out_stream << (*last).first << "=" << (*last).second << '\n';
+    }
+
+private:
+    std::string chrom{};
+    std::uint64_t pos{};
+    std::string id{"."};
+    std::string ref{"N"};
+    std::string alt{};
+    float qual{};
+    std::string filter{"PASS"};
+    std::map<std::string, std::string> info{};
+};

--- a/test/api/deletion_finding_and_printing_test.cpp
+++ b/test/api/deletion_finding_and_printing_test.cpp
@@ -35,11 +35,14 @@ TEST(group1, test_std_out)
     std::string std_cout = testing::internal::GetCapturedStdout();
     std::string expected
     {
-        "##fileformat=VCFv4.2\n"
+        "##fileformat=VCFv4.3\n"
         "##source=iGenVarCaller\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+        "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
         "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
-        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-50;END=9435286\n"
-        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-248;END=11104822\n"
+        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tEND=9435286;SVLEN=-50;SVTYPE=DEL\n"
+        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tEND=11104822;SVLEN=-248;SVTYPE=DEL\n"
     };
     EXPECT_EQ(std_cout, expected);
 }

--- a/test/api/deletion_finding_and_printing_test.cpp
+++ b/test/api/deletion_finding_and_printing_test.cpp
@@ -15,11 +15,14 @@ TEST(group1, test_out_file)
     buffer << f.rdbuf();
     std::string expected
     {
-        "##fileformat=VCFv4.2\n"
+        "##fileformat=VCFv4.3\n"
         "##source=iGenVarCaller\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+        "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
         "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
-        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-50;END=9435286\n"
-        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-248;END=11104822\n"
+        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tEND=9435286;SVLEN=-50;SVTYPE=DEL\n"
+        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tEND=11104822;SVLEN=-248;SVTYPE=DEL\n"
     };
     EXPECT_TRUE(f.is_open());
     EXPECT_EQ(buffer.str(), expected);

--- a/test/cli/find_deletions_cli_test.cpp
+++ b/test/cli/find_deletions_cli_test.cpp
@@ -35,10 +35,14 @@ TEST_F(find_deletions, with_one_argument)
                                          "-i", data("detect_breakends_shorted.vcf"));
     std::string expected
     {
-        "##fileformat=VCFv4.2\n##source=iGenVarCaller\n"
+        "##fileformat=VCFv4.3\n"
+        "##source=iGenVarCaller\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+        "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
         "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
-        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-50;END=9435286\n"
-        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-248;END=11104822\n"
+        "chr21\t9435236\t.\tN\t<DEL>\t60\tPASS\tEND=9435286;SVLEN=-50;SVTYPE=DEL\n"
+        "chr21\t11104574\t.\tN\t<DEL>\t60\tPASS\tEND=11104822;SVLEN=-248;SVTYPE=DEL\n"
     };
 
     EXPECT_EQ(result.exit_code, 0);


### PR DESCRIPTION
Resolves #9 and resolves #10.

Here I introduce a skeleton VCF parser to address issue #29. It doesn't really do any checking to make sure values are valid, but it does provide a template for information regarding variants to be stored in a VCF format-friendly way. 

Some things up for discussion:
1. Currently, the INFO header is stored in a vector of info_entry objects. In the variants themselves, the respective INFO entries are stored in a map, with the key being the INFO name and the value being the INFO value... I'm not too satisfied with this current implementation (to have a std::map for every variant seems unnecessary).
2. Constructors for `variant_header` and `variant_record` are currently empty, because I figured all of the information is not always known on construction. But maybe it makes sense to change this?
3. The INFO field can store various types of information (integers, floats, flags, characters, and strings). Currently, everything is being stored as a string as I wasn't sure the best way to do this.