### PR TITLE
[FIX] Rearrange parameters of analyze_cigar()

### DIFF
--- a/src/detect_breakends/junction_detection.cpp
+++ b/src/detect_breakends/junction_detection.cpp
@@ -85,7 +85,7 @@ void retrieve_aligned_segments(std::string sa_string, std::vector<AlignedSegment
  */
 void analyze_aligned_segments(const std::vector<AlignedSegment> & aligned_segments,
                               std::vector<Junction> & junctions,
-                              std::string & read_name)
+                              const std::string & read_name)
 {
     for(size_t i = 1; i<aligned_segments.size(); i++)
     {
@@ -114,8 +114,8 @@ void analyze_aligned_segments(const std::vector<AlignedSegment> & aligned_segmen
 
 /*! \brief This function steps through the CIGAR string and stores junctions with their position in reference and read.
  *
- * \param chromosome        RNAME field of the SAM/BAM file
  * \param read_name         QNAME field of the SAM/BAM file
+ * \param chromosome        RNAME field of the SAM/BAM file
  * \param query_start_pos   POS field of the SAM/BAM file
  * \param cigar_string      CIGAR field of the SAM/BAM file
  * \param query_sequence    SEQ field of the SAM/BAM file
@@ -141,11 +141,11 @@ void analyze_aligned_segments(const std::vector<AlignedSegment> & aligned_segmen
  *          For more information see the
  *          ([Map Format Specification](https://github.com/samtools/hts-specs/blob/master/SAMv1.pdf)) page 8.
  */
-void analyze_cigar(std::string chromosome,
-                   std::string & read_name,
-                   int32_t query_start_pos,
+void analyze_cigar(const std::string & read_name,
+                   const std::string chromosome,
+                   const int32_t query_start_pos,
                    std::vector<seqan3::cigar> & cigar_string,
-                   seqan3::dna5_vector & query_sequence,
+                   const seqan3::dna5_vector & query_sequence,
                    std::vector<Junction> & junctions,
                    std::vector<seqan3::dna5_vector> & insertions,
                    int32_t min_length,
@@ -281,17 +281,17 @@ void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_
 
     for (auto & rec : alignment_file)
     {
-        std::string query_name = seqan3::get<seqan3::field::id>(rec);
-        int32_t ref_id = seqan3::get<seqan3::field::ref_id>(rec).value_or(0);
-        int32_t pos = seqan3::get<seqan3::field::ref_offset>(rec).value_or(0);
-        seqan3::sam_flag const flag = seqan3::get<seqan3::field::flag>(rec);    // uint16_t enum
-        uint8_t const mapq = seqan3::get<seqan3::field::mapq>(rec);
-        auto cigar = seqan3::get<seqan3::field::cigar>(rec);
-        auto seq = seqan3::get<seqan3::field::seq>(rec);
-        auto tags = seqan3::get<seqan3::field::tags>(rec);
-        auto header_ptr = seqan3::get<seqan3::field::header_ptr>(rec);
-        auto ref_ids = header_ptr->ref_ids();
-        std::string ref_name = ref_ids[ref_id];
+        const std::string query_name            = seqan3::get<seqan3::field::id>(rec);                      // 1: QNAME
+        const seqan3::sam_flag flag             = seqan3::get<seqan3::field::flag>(rec);                    // 2: FLAG
+        const int32_t ref_id                    = seqan3::get<seqan3::field::ref_id>(rec).value_or(0);      // 3: RNAME
+        const int32_t pos                       = seqan3::get<seqan3::field::ref_offset>(rec).value_or(0);  // 4: POS
+        const uint8_t mapq                      = seqan3::get<seqan3::field::mapq>(rec);                    // 5: MAPQ
+        std::vector<seqan3::cigar> cigar        = seqan3::get<seqan3::field::cigar>(rec);                   // 6: CIGAR
+        const auto seq                          = seqan3::get<seqan3::field::seq>(rec);                     // 10:SEQ
+        auto tags                               = seqan3::get<seqan3::field::tags>(rec);
+        const auto header_ptr                   = seqan3::get<seqan3::field::header_ptr>(rec);
+        const auto ref_ids = header_ptr->ref_ids();
+        const std::string ref_name = ref_ids[ref_id];
 
         if (hasFlagUnmapped(flag) || hasFlagSecondary(flag) || hasFlagDuplicate(flag) || mapq < 20)
         {

--- a/test/api/junction_detection_test.cpp
+++ b/test/api/junction_detection_test.cpp
@@ -14,25 +14,25 @@
 //     EXPECT_EQ(expected, std_cout);
 // }
 
-// Explanation for the stings:
-// Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\tchr21
-// INS from Primary Read - Sequence Type: Reference; Sequence Name: m2257/8161/CCS; Position: 41972616; Orientation: Reverse
-//                         Sequence Type: Read; Sequence Name: 0; Position: 3975; Orientation: Reverse
-//                         Chromosome: chr21
-// Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS
+// Explanation for the strings:
+// Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1
+// INS from Primary Read - Sequence Type: Reference; Chromosome: chr21; Position: 41972616; Orientation: Forward
+//                         Sequence Type: Read; Chromosome: 0; Position: 2294; Orientation: Forward
+//                         Supporting Reads: 1
+// Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1
 // BND from SA Tag - Sequence Type: Reference; Chromosome: chr22; Position: 17458417; Orientation: Forward
 //                   Sequence Type: Reference; Chromosome: chr21; Position: 41972615; Orientation: Forward
-//                   Sequence Name: m41327/11677/CCS
+//                   Supporting Reads: 1
 
 uint64_t sv_default_length = 30;
 
 TEST(junction_detection, fasta_out_not_empty)
 {
     std::string expected{
+        "Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -59,8 +59,8 @@ TEST(junction_detection, fasta_out_not_empty)
 TEST(junction_detection, method_1_only)
 {
     std::string expected{
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
+        "Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -111,10 +111,10 @@ TEST(junction_detection, method_2_only)
 TEST(junction_detection, method_1_and_2)
 {
     std::string expected{
+        "Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -140,11 +140,12 @@ TEST(junction_detection, method_1_and_2)
 
 TEST(junction_detection, refinement_method_sViper)
 {
-    std::string expected{
+    std::string expected
+    {
+        "Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -168,11 +169,12 @@ TEST(junction_detection, refinement_method_sViper)
 
 TEST(junction_detection, refinement_method_sVirl)
 {
-    std::string expected{
+    std::string expected
+    {
+        "Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory

--- a/test/cli/detect_breakends_cli_test.cpp
+++ b/test/cli/detect_breakends_cli_test.cpp
@@ -40,15 +40,15 @@ TEST_F(detect_breakends, with_arguments)
                                          "detect_breakends_insertion_file_out.fasta");
     std::string expected
     {
+        "Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
     std::string expected_err
     {
-        "INS1: Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\tchr21\n"
-        "INS2: Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\tchr21\n"
+        "INS1: Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\tm2257/8161/CCS\n"
+        "INS2: Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\tm2257/8161/CCS\n"
         "The read pair method is not yet implemented.\n"
         "The read depth method is not yet implemented.\n"
         "BND: Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\n"


### PR DESCRIPTION
Resolves #52 

I made a mix up in the analyze_cigar(), which caused a wrong output.
=> I Rearranged the parameters of analyze_cigar()
I also made const parameter const, repaired the tests and updated the documentation
