### PR TITLE
[FEATURE] New option for the minimum length of variants to detect.

### DIFF
--- a/include/detect_breakends/junction_detection.hpp
+++ b/include/detect_breakends/junction_detection.hpp
@@ -22,6 +22,7 @@
  *                                                           1: hierarchical_clustering,
  *                                                           2: self-balancing_binary_tree,
  *                                                           3: candidate_selection_based_on_voting)
+ * \param min_var_length - minimum length of variants to detect (default 30 bp)
  *
  * \details Detects junctions from the CIGAR strings and supplementary alignment tags of read alignment records.
  *          We sort out unmapped alignments, secondary alignments, duplicates and alignments with low mapping quality.
@@ -31,4 +32,5 @@
 void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_file_path,
                                         const std::filesystem::path & insertion_file_path,
                                         const std::vector<uint8_t> methods,
-                                        const clustering_methods clustering_method);
+                                        const clustering_methods clustering_method,
+                                        const uint64_t min_var_length);

--- a/src/detect_breakends.cpp
+++ b/src/detect_breakends.cpp
@@ -31,6 +31,7 @@ struct cmd_arguments
     std::filesystem::path insertion_file_path{};
     std::vector<uint8_t> methods{1, 2, 3, 4};                   // default is using all methods
     clustering_methods clustering_method{simple_clustering};    // default is the simple clustering method
+    uint64_t min_var_length = 30;
 };
 
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
@@ -66,6 +67,11 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       seqan3::option_spec::advanced, method_validator);
     parser.add_option(args.clustering_method, 'c', "clustering_method", "Choose the clustering method to be used.",
                       seqan3::option_spec::advanced, clustering_method_validator);
+
+    // Options - SV specifications:
+    parser.add_option(args.min_var_length, 'l', "min_var_length",
+                      "Specify what should be the minimum length of your SVs to be detected (default 30 bp).",
+                      seqan3::option_spec::advanced);
 }
 
 int main(int argc, char ** argv)
@@ -88,7 +94,8 @@ int main(int argc, char ** argv)
     detect_junctions_in_alignment_file(args.alignment_file_path,
                                        args.insertion_file_path,
                                        args.methods,
-                                       args.clustering_method);
+                                       args.clustering_method,
+                                       args.min_var_length);
 
     return 0;
 }

--- a/src/detect_breakends/junction_detection.cpp
+++ b/src/detect_breakends/junction_detection.cpp
@@ -112,7 +112,7 @@ void analyze_aligned_segments(const std::vector<aligned_segment> & aligned_segme
  * \param query_sequence    SEQ field of the SAM/BAM file
  * \param junctions         vector for storing junctions
  * \param insertions        vector for storing insertion_alleles
- * \param min_length        minimum length of variants to detect (currently 30 bp)
+ * \param min_length        minimum length of variants to detect (default 30 bp)
  * \param insertion_file    output file for insertion alleles
  *
  * \details This function steps through the CIGAR string and stores junctions with their position in reference and read.
@@ -228,6 +228,7 @@ void analyze_cigar(std::string chromosome,
  *                                                           1: hierarchical_clustering,
  *                                                           2: self-balancing_binary_tree,
  *                                                           3: candidate_selection_based_on_voting)
+ * \param min_var_length - minimum length of variants to detect (default 30 bp)
  * \endcond
  *
  * \details Detects junctions from the CIGAR strings and supplementary alignment tags of read alignment records.
@@ -242,7 +243,8 @@ void analyze_cigar(std::string chromosome,
 void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_file_path,
                                         const std::filesystem::path & insertion_file_path,
                                         const std::vector<uint8_t> methods,
-                                        const clustering_methods clustering_method)
+                                        const clustering_methods clustering_method,
+                                        const uint64_t min_var_length)
 {
     // Open input alignment file
     using my_fields = seqan3::fields<seqan3::field::id,
@@ -295,7 +297,7 @@ void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_
                                       seq,
                                       junctions,
                                       insertion_alleles,
-                                      30,
+                                      min_var_length,
                                       insertion_file);
                         break;
                     case 2: // Detect junctions from split read evidence (SA tag, primary alignments only)

--- a/test/api/junction_detection_test.cpp
+++ b/test/api/junction_detection_test.cpp
@@ -24,6 +24,8 @@
 //                   Sequence Type: Reference; Chromosome: chr21; Position: 41972615; Orientation: Forward
 //                   Sequence Name: m41327/11677/CCS
 
+uint64_t sv_default_length = 30;
+
 TEST(junction_detection, fasta_out_not_empty)
 {
     std::string expected{
@@ -38,7 +40,10 @@ TEST(junction_detection, fasta_out_not_empty)
 
     testing::internal::CaptureStdout();
     detect_junctions_in_alignment_file(DATADIR"simulated.minimap2.hg19.coordsorted_cutoff.sam",
-                                       tmp_dir/"detect_breakends_out_short.fasta", {1, 2, 3, 4}, simple_clustering);
+                                       tmp_dir/"detect_breakends_out_short.fasta",
+                                       {1, 2, 3, 4},
+                                       simple_clustering,
+                                       sv_default_length);
 
     std::string std_cout = testing::internal::GetCapturedStdout();
     seqan3::debug_stream << "std_out:\n" << std_cout << '\n';
@@ -60,7 +65,10 @@ TEST(junction_detection, method_1_only)
 
     testing::internal::CaptureStdout();
     detect_junctions_in_alignment_file(DATADIR"simulated.minimap2.hg19.coordsorted_cutoff.sam",
-                                       tmp_dir/"detect_breakends_out_short.fasta", {1}, simple_clustering);
+                                       tmp_dir/"detect_breakends_out_short.fasta",
+                                       {1},
+                                       simple_clustering,
+                                       sv_default_length);
 
     std::string std_cout = testing::internal::GetCapturedStdout();
     seqan3::debug_stream << "std_out:\n" << std_cout << '\n';
@@ -82,7 +90,10 @@ TEST(junction_detection, method_2_only)
 
     testing::internal::CaptureStdout();
     detect_junctions_in_alignment_file(DATADIR"simulated.minimap2.hg19.coordsorted_cutoff.sam",
-                                       tmp_dir/"detect_breakends_out_short.fasta", {2}, simple_clustering);
+                                       tmp_dir/"detect_breakends_out_short.fasta",
+                                       {2},
+                                       simple_clustering,
+                                       sv_default_length);
 
     std::string std_cout = testing::internal::GetCapturedStdout();
     seqan3::debug_stream << "std_out:\n" << std_cout << '\n';
@@ -106,7 +117,10 @@ TEST(junction_detection, method_1_and_2)
 
     testing::internal::CaptureStdout();
     detect_junctions_in_alignment_file(DATADIR"simulated.minimap2.hg19.coordsorted_cutoff.sam",
-                                       tmp_dir/"detect_breakends_out_short.fasta", {1, 2}, simple_clustering);
+                                       tmp_dir/"detect_breakends_out_short.fasta",
+                                       {1, 2},
+                                       simple_clustering,
+                                       sv_default_length);
 
     std::string std_cout = testing::internal::GetCapturedStdout();
     seqan3::debug_stream << "std_out:\n" << std_cout << '\n';


### PR DESCRIPTION
resolves first part of https://github.com/seqan/iGenVar/issues/57

I have changed that we can specify a SV length as input parameter, the default remains at 30bp.
