### PR TITLE
[FEATURE] New class cluster for groups of similar junctions

### DIFF
--- a/include/breakend.hpp
+++ b/include/breakend.hpp
@@ -35,7 +35,7 @@ struct breakend
 template <typename stream_t>
 inline stream_t operator<<(stream_t && stream, breakend const & b)
 {
-    stream << ((b.seq_type == sequence_type::reference) ? "Reference" : "Read ") << '\t'
+    stream << ((b.seq_type == sequence_type::reference) ? "Reference" : "Read") << '\t'
            << b.seq_name << '\t'
            << b.position  << '\t'
            << ((b.orientation == strand::forward) ? "Forward" : "Reverse");

--- a/include/cluster.hpp
+++ b/include/cluster.hpp
@@ -1,6 +1,7 @@
 
 #include <utility>
 #include <cmath>
+#include <stdexcept>
 
 class cluster
 {
@@ -12,10 +13,10 @@ public:
      * \{
      */
     constexpr cluster()                    = default; //!< Defaulted.
-    cluster(cluster const &)              = default; //!< Defaulted.
-    cluster(cluster &&)                   = default; //!< Defaulted.
-    cluster & operator=(cluster const &)  = default; //!< Defaulted.
-    cluster & operator=(cluster &&)       = default; //!< Defaulted.
+    cluster(cluster const &)               = default; //!< Defaulted.
+    cluster(cluster &&)                    = default; //!< Defaulted.
+    cluster & operator=(cluster const &)   = default; //!< Defaulted.
+    cluster & operator=(cluster &&)        = default; //!< Defaulted.
     ~cluster()                             = default; //!< Defaulted.
     //!\}
 
@@ -23,19 +24,19 @@ public:
     {
         
     }
-    uint64_t get_cluster_size() const
+    size_t get_cluster_size() const
     {
         return members.size();
     }
 
     breakend get_average_mate1() const
     {
-        sequence_type seq_type;
-        std::string seq_name;
+        sequence_type seq_type{};
+        std::string seq_name{};
         uint64_t sum_positions = 0;
-        strand orientation;
+        strand orientation{};
         // Iterate through members of the cluster
-        for (uint32_t i=0; i<members.size(); i++)
+        for (uint32_t i = 0; i < members.size(); ++i)
         {
             breakend mate1 = members[i].get_mate1();
             if (i == 0)
@@ -57,19 +58,19 @@ public:
             // Add up breakend positions aross all members
             sum_positions += mate1.position;
         }
-        int32_t average_position = round(sum_positions / members.size());
+        int32_t average_position = std::round(static_cast<double>(sum_positions) / members.size());
         breakend average_breakend{seq_name, average_position, orientation, seq_type};
         return average_breakend;
     }
 
     breakend get_average_mate2() const
     {
-        sequence_type seq_type;
-        std::string seq_name;
+        sequence_type seq_type{};
+        std::string seq_name{};
         uint64_t sum_positions = 0;
-        strand orientation;
+        strand orientation{};
         // Iterate through members of the cluster
-        for (uint32_t i=0; i<members.size(); i++)
+        for (uint32_t i = 0; i < members.size(); ++i)
         {
             breakend mate2 = members[i].get_mate2();
             if (i == 0)
@@ -91,7 +92,7 @@ public:
             // Add up breakend positions aross all members
             sum_positions += mate2.position;
         }
-        int32_t average_position = round(sum_positions / members.size());
+        int32_t average_position = std::round(static_cast<double>(sum_positions) / members.size());
         breakend average_breakend{seq_name, average_position, orientation, seq_type};
         return average_breakend;
     }

--- a/include/cluster.hpp
+++ b/include/cluster.hpp
@@ -1,0 +1,107 @@
+
+#include <utility>
+#include <cmath>
+
+class cluster
+{
+private:
+    std::vector<junction> members{};
+
+public:
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    constexpr cluster()                    = default; //!< Defaulted.
+    cluster(cluster const &)              = default; //!< Defaulted.
+    cluster(cluster &&)                   = default; //!< Defaulted.
+    cluster & operator=(cluster const &)  = default; //!< Defaulted.
+    cluster & operator=(cluster &&)       = default; //!< Defaulted.
+    ~cluster()                             = default; //!< Defaulted.
+    //!\}
+
+    cluster(std::vector<junction> members) : members{std::move(members)}
+    {
+        
+    }
+    uint64_t get_cluster_size() const
+    {
+        return members.size();
+    }
+
+    breakend get_average_mate1() const
+    {
+        sequence_type seq_type;
+        std::string seq_name;
+        uint64_t sum_positions = 0;
+        strand orientation;
+        // Iterate through members of the cluster
+        for (uint32_t i=0; i<members.size(); i++)
+        {
+            breakend mate1 = members[i].get_mate1();
+            if (i == 0)
+            {
+                seq_type = mate1.seq_type;
+                seq_name = mate1.seq_name;
+                orientation = mate1.orientation;
+            }
+            else
+            {
+                // Make sure that all members of the cluster have matching sequence types, names and orientations
+                if (mate1.seq_type != seq_type ||
+                    mate1.seq_name != seq_name ||
+                    mate1.orientation != orientation)
+                {
+                    throw std::runtime_error("Junctions with incompatible breakends were clustered together (different seq_type, seq_name or orientation).");
+                }
+            }
+            // Add up breakend positions aross all members
+            sum_positions += mate1.position;
+        }
+        int32_t average_position = round(sum_positions / members.size());
+        breakend average_breakend{seq_name, average_position, orientation, seq_type};
+        return average_breakend;
+    }
+
+    breakend get_average_mate2() const
+    {
+        sequence_type seq_type;
+        std::string seq_name;
+        uint64_t sum_positions = 0;
+        strand orientation;
+        // Iterate through members of the cluster
+        for (uint32_t i=0; i<members.size(); i++)
+        {
+            breakend mate2 = members[i].get_mate2();
+            if (i == 0)
+            {
+                seq_type = mate2.seq_type;
+                seq_name = mate2.seq_name;
+                orientation = mate2.orientation;
+            }
+            else
+            {
+                // Make sure that all members of the cluster have matching sequence types, names and orientations
+                if (mate2.seq_type != seq_type ||
+                    mate2.seq_name != seq_name ||
+                    mate2.orientation != orientation)
+                {
+                    throw std::runtime_error("Junctions with incompatible breakends were clustered together (different seq_type, seq_name or orientation).");
+                }
+            }
+            // Add up breakend positions aross all members
+            sum_positions += mate2.position;
+        }
+        int32_t average_position = round(sum_positions / members.size());
+        breakend average_breakend{seq_name, average_position, orientation, seq_type};
+        return average_breakend;
+    }
+};
+
+template <typename stream_t>
+inline stream_t operator<<(stream_t && stream, cluster const & clust)
+{
+    stream << clust.get_average_mate1() << '\t'
+           << clust.get_average_mate2() << '\t'
+           << clust.get_cluster_size();
+    return stream;
+}

--- a/include/cluster.hpp
+++ b/include/cluster.hpp
@@ -1,7 +1,7 @@
 
-#include <utility>
 #include <cmath>
 #include <stdexcept>
+#include <utility>
 
 class cluster
 {

--- a/include/detect_breakends/junction_detection.hpp
+++ b/include/detect_breakends/junction_detection.hpp
@@ -6,6 +6,7 @@
 
 #include "detect_breakends/bam_functions.hpp"   // for hasFlag* functions
 #include "junction.hpp"                         // for class junction
+#include "cluster.hpp"                         // for class cluster
 #include "detect_breakends/aligned_segment.hpp" // for struct aligned_segment
 #include "method_enums.hpp"                     // for enum clustering_methods
 

--- a/include/junction.hpp
+++ b/include/junction.hpp
@@ -10,8 +10,6 @@ private:
     std::string read_name{};
 
 public:
-    uint64_t supporting_reads{1};
-
     /*!\name Constructors, destructor and assignment
      * \{
      */
@@ -56,8 +54,7 @@ inline stream_t operator<<(stream_t && stream, junction const & junc)
 {
     stream << junc.get_mate1() << '\t'
            << junc.get_mate2() << '\t'
-           << junc.get_read_name() << '\t'
-           << junc.supporting_reads;
+           << junc.get_read_name();
     return stream;
 }
 

--- a/src/detect_breakends/junction_detection.cpp
+++ b/src/detect_breakends/junction_detection.cpp
@@ -333,25 +333,29 @@ void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_
     }
     std::sort(junctions.begin(), junctions.end());
 
+    seqan3::debug_stream << "Start clustering...\n";
+
+    std::vector<cluster> clusters{};
     switch (clustering_method)
     {
         case 0: // simple_clustering
             {
-                junction previous_elem = junctions[0];
+                std::vector<junction> current_cluster_members = {junctions[0]};
                 int i = 1;
                 while (i < junctions.size())
                 {
-                    if (junctions[i] == previous_elem)
+                    if (junctions[i] == current_cluster_members.back())
                     {
-                        junctions.erase(junctions.begin() + i);
-                        junctions[i].supporting_reads ++;
+                        current_cluster_members.push_back(junctions[i]);
                     }
                     else
                     {
-                        previous_elem = junctions[i];
-                        i++;
+                        clusters.emplace_back(current_cluster_members);
+                        current_cluster_members = {junctions[i]};
                     }
+                    i++;
                 }
+                clusters.emplace_back(current_cluster_members);
             }
             break;
         case 1: // hierarchical clustering
@@ -365,9 +369,10 @@ void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_
             break;
     }
 
-    for (junction elem : junctions)
+    seqan3::debug_stream << "Done with clustering. Found " << clusters.size() << " junction clusters.\n";
+
+    for (cluster elem : clusters)
     {
         std::cout << elem << '\n';
     }
-    seqan3::debug_stream << "Done. Found " << junctions.size() << " junctions.\n";
 }

--- a/src/detect_breakends/junction_detection.cpp
+++ b/src/detect_breakends/junction_detection.cpp
@@ -353,7 +353,7 @@ void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_
                         clusters.emplace_back(current_cluster_members);
                         current_cluster_members = {junctions[i]};
                     }
-                    i++;
+                    ++i;
                 }
                 clusters.emplace_back(current_cluster_members);
             }
@@ -371,7 +371,7 @@ void detect_junctions_in_alignment_file(const std::filesystem::path & alignment_
 
     seqan3::debug_stream << "Done with clustering. Found " << clusters.size() << " junction clusters.\n";
 
-    for (cluster elem : clusters)
+    for (cluster const & elem : clusters)
     {
         std::cout << elem << '\n';
     }

--- a/test/api/junction_detection_test.cpp
+++ b/test/api/junction_detection_test.cpp
@@ -15,7 +15,7 @@
 // }
 
 // Explanation for the stings:
-// Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\tchr21
+// Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\tchr21
 // INS from Primary Read - Sequence Type: Reference; Sequence Name: m2257/8161/CCS; Position: 41972616; Orientation: Reverse
 //                         Sequence Type: Read; Sequence Name: 0; Position: 3975; Orientation: Reverse
 //                         Chromosome: chr21
@@ -29,8 +29,8 @@ TEST(junction_detection, fasta_out_not_empty)
     std::string expected{
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -51,8 +51,8 @@ TEST(junction_detection, fasta_out_not_empty)
 TEST(junction_detection, method_1_only)
 {
     std::string expected{
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\tchr21\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\tchr21\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -97,8 +97,8 @@ TEST(junction_detection, method_1_and_2)
     std::string expected{
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory

--- a/test/api/junction_detection_test.cpp
+++ b/test/api/junction_detection_test.cpp
@@ -27,10 +27,10 @@
 TEST(junction_detection, fasta_out_not_empty)
 {
     std::string expected{
-        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\t1\n"
-        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\tchr21\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\tchr21\t1\n"
+        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
+        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -73,8 +73,8 @@ TEST(junction_detection, method_1_only)
 TEST(junction_detection, method_2_only)
 {
     std::string expected{
-        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\t1\n"
-        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\t1\n"
+        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
+        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory
@@ -95,10 +95,10 @@ TEST(junction_detection, method_2_only)
 TEST(junction_detection, method_1_and_2)
 {
     std::string expected{
-        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\t1\n"
-        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\tchr21\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\tchr21\t1\n"
+        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
+        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\t1\n"
     };
 
     std::filesystem::path tmp_dir = std::filesystem::temp_directory_path();     // get the temp directory

--- a/test/cli/detect_breakends_cli_test.cpp
+++ b/test/cli/detect_breakends_cli_test.cpp
@@ -42,8 +42,8 @@ TEST_F(detect_breakends, with_arguments)
     {
         "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
         "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
     std::string expected_err
     {
@@ -62,10 +62,6 @@ TEST_F(detect_breakends, with_arguments)
         "The read depth method is not yet implemented.\n"
         "Start clustering...\n"
         "Done with clustering. Found 4 junction clusters.\n"
-        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
-        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected);

--- a/test/cli/detect_breakends_cli_test.cpp
+++ b/test/cli/detect_breakends_cli_test.cpp
@@ -40,27 +40,32 @@ TEST_F(detect_breakends, with_arguments)
                                          "detect_breakends_insertion_file_out.fasta");
     std::string expected
     {
-        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\t1\n"
-        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\t1\n"
-        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\tchr21\t2\n"
-        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\tchr21\t1\n"
+        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
+        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\t1\n"
     };
     std::string expected_err
     {
-        "INS1: Reference\tm2257/8161/CCS\t41972616\tForward\tRead \t0\t2294\tForward\tchr21\t1\n"
-        "INS2: Reference\tm2257/8161/CCS\t41972616\tReverse\tRead \t0\t3975\tReverse\tchr21\t1\n"
+        "INS1: Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\tchr21\n"
+        "INS2: Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\tchr21\n"
         "The read pair method is not yet implemented.\n"
         "The read depth method is not yet implemented.\n"
-        "BND: Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\t1\n"
+        "BND: Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\n"
         "The read pair method is not yet implemented.\n"
         "The read depth method is not yet implemented.\n"
-        "BND: Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\t1\n"
+        "BND: Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\n"
         "The read pair method is not yet implemented.\n"
         "The read depth method is not yet implemented.\n"
-        "BND: Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm38637/7161/CCS\t1\n"
+        "BND: Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm38637/7161/CCS\n"
         "The read pair method is not yet implemented.\n"
         "The read depth method is not yet implemented.\n"
-        "Done. Found 4 junctions.\n"
+        "Start clustering...\n"
+        "Done with clustering. Found 4 junction clusters.\n"
+        "Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\t1\n"
+        "Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\t2\n"
+        "Reference\tm2257/8161/CCS\t41972616\tForward\tRead\t0\t2294\tForward\t1\n"
+        "Reference\tm2257/8161/CCS\t41972616\tReverse\tRead\t0\t3975\tReverse\t1\n"
     };
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected);


### PR DESCRIPTION
This PR adds a new class `cluster` that represents a cluster of junctions by holding an `std::vector<junction>`. The new class implements public methods `get_average_mate1()` and `get_average_mate2` to obtain the average of all junctions in the cluster. The PR also updates the simple clustering method to use the new `cluster` class. The PR resolves #51.

I'm not very experienced with C++ and the coding guidelines yet. So please don't be shy in the reviews and point out all the potentially ugly parts of my code 🙂 Also: I was not able to run the tests on my machine (see #48) so they might be broken.