### PR TITLE
[FIX] Fix EnumValidator

### DIFF
--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -102,8 +102,7 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.add_option(args.output_file_path, 'o', "output",
                       "The path of the vcf output file. If no path is given, will output to standard output.",
                       seqan3::option_spec::standard,
-                      seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create,
-                                                               {"vcf"}});
+                      seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"vcf"}});
 
     // Options - Methods:
     parser.add_option(args.methods, 'm', "method", "Choose the detection method(s) to be used.",

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -81,12 +81,8 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.info.url = "https://github.com/seqan/iGenVar/";
 
     // Validatiors:
-    seqan3::value_list_validator detection_method_validator {
-        (seqan3::enumeration_names<detection_methods> | std::views::values)
-    };
-    // ToDo (Lydia): Should get solved with solving https://github.com/seqan/iGenVar/issues/78
-    // EnumValidator<detecting_methods> detecting_method_validator{seqan3::enumeration_names<detecting_methods>
-    //                                                             | std::views::values};
+    EnumValidator<detection_methods> detection_method_validator{seqan3::enumeration_names<detection_methods>
+                                                                | std::views::values};
     EnumValidator<clustering_methods> clustering_method_validator{seqan3::enumeration_names<clustering_methods>
                                                                   | std::views::values};
     EnumValidator<refinement_methods> refinement_method_validator{seqan3::enumeration_names<refinement_methods>

--- a/src/variant_detection/variant_detection.cpp
+++ b/src/variant_detection/variant_detection.cpp
@@ -39,21 +39,21 @@ void detect_junctions_in_long_reads_sam_file(std::vector<Junction> & junctions,
     }
     uint16_t num_good = 0;
 
-    for (auto & rec : alignment_long_reads_file)
+    for (auto & record : alignment_long_reads_file)
     {
-        std::string const query_name        = seqan3::get<seqan3::field::id>(rec);                      // 1: QNAME
-        seqan3::sam_flag const flag         = seqan3::get<seqan3::field::flag>(rec);                    // 2: FLAG
-        int32_t const ref_id                = seqan3::get<seqan3::field::ref_id>(rec).value_or(-1);     // 3: RNAME
-        int32_t const pos                   = seqan3::get<seqan3::field::ref_offset>(rec).value_or(-1); // 4: POS
-        uint8_t const mapq                  = seqan3::get<seqan3::field::mapq>(rec);                    // 5: MAPQ
-        std::vector<seqan3::cigar> cigar    = seqan3::get<seqan3::field::cigar>(rec);                   // 6: CIGAR
-        auto const seq                      = seqan3::get<seqan3::field::seq>(rec);                     // 10:SEQ
-        auto tags                           = seqan3::get<seqan3::field::tags>(rec);
-        auto const header_ptr               = seqan3::get<seqan3::field::header_ptr>(rec);
+        std::string const query_name        = record.id();                              // 1: QNAME
+        seqan3::sam_flag const flag         = record.flag();                            // 2: FLAG
+        int32_t const ref_id                = record.reference_id().value_or(-1);       // 3: RNAME
+        int32_t const ref_pos               = record.reference_position().value_or(-1); // 4: POS
+        uint8_t const mapq                  = record.mapping_quality();                 // 5: MAPQ
+        std::vector<seqan3::cigar> cigar    = record.cigar_sequence();                  // 6: CIGAR
+        auto const seq                      = record.sequence();                        // 10:SEQ
+        auto tags                           = record.tags();
+        auto const header_ptr               = record.header_ptr();
         auto const ref_ids = header_ptr->ref_ids();
 
         if (hasFlagUnmapped(flag) || hasFlagSecondary(flag) || hasFlagDuplicate(flag) || mapq < 20 ||
-            ref_id < 0 || pos < 0)
+            ref_id < 0 || ref_pos < 0)
             continue;
 
         std::string const ref_name = ref_ids[ref_id];
@@ -63,7 +63,7 @@ void detect_junctions_in_long_reads_sam_file(std::vector<Junction> & junctions,
                 case detection_methods::cigar_string: // Detect junctions from CIGAR string
                     analyze_cigar(query_name,
                                   ref_name,
-                                  pos,
+                                  ref_pos,
                                   cigar,
                                   seq,
                                   junctions,
@@ -75,7 +75,7 @@ void detect_junctions_in_long_reads_sam_file(std::vector<Junction> & junctions,
                         std::string const sa_tag = tags.get<"SA"_tag>();
                         if (!sa_tag.empty())
                         {
-                            analyze_sa_tag(query_name, flag, ref_name, pos, mapq, cigar, seq, sa_tag, junctions);
+                            analyze_sa_tag(query_name, flag, ref_name, ref_pos, mapq, cigar, seq, sa_tag, junctions);
                         }
                     }
                     break;

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -93,5 +93,4 @@ protected:
     }
 };
 
-struct detect_breakends : public cli_test {};
-struct find_deletions : public cli_test {};
+struct iGenVar_cli_test : public cli_test {};

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -68,11 +68,8 @@ std::string const help_page_advanced
     "    -m, --method (List of detection_methods)\n"
     "          Choose the detection method(s) to be used. Default:\n"
     "          [cigar_string,split_read,read_pairs,read_depth]. Value must be one\n"
-    "          of\n"
-    "          [read_depth,read_depth,read_pairs,read_pairs,split_read,split_read,cigar_string,cigar_string].\n"
-    // ToDo (Lydia): Should get solved with solving https://github.com/seqan/iGenVar/issues/78
-    // "          of (method name or number)\n"
-    // "          [cigar_string,0,split_read,1,read_pairs,2,read_depth,3].\n"
+    "          of (method name or number)\n"
+    "          [cigar_string,0,split_read,1,read_pairs,2,read_depth,3].\n"
     "    -c, --clustering_method (clustering_methods)\n"
     "          Choose the clustering method to be used. Default: simple_clustering.\n"
     "          Value must be one of (method name or number)\n"
@@ -209,6 +206,31 @@ TEST_F(detect_breakends, with_detection_method_duplicate_arguments)
     };
     EXPECT_NE(result.exit_code, 0);
     EXPECT_EQ(result.out, "");
+    EXPECT_EQ(result.err, expected_err);
+}
+
+TEST_F(detect_breakends, test_direct_methods_input)
+{
+    cli_test_result result = execute_app("iGenVar",
+                                         "-j", data(default_alignment_long_reads_file_path),
+                                         fasta_out_file_path,
+                                         "-m 0 -m 1 -c 0 -r 0");
+
+    std::cout << "Current path is " << std::filesystem::current_path() << '\n';
+
+    std::string expected_err
+    {
+        "INS1: Reference\tchr21\t41972616\tForward\tRead\t0\t2294\tForward\tm2257/8161/CCS\n"
+        "INS2: Reference\tchr21\t41972616\tReverse\tRead\t0\t3975\tReverse\tm2257/8161/CCS\n"
+        "BND: Reference\tchr22\t17458417\tForward\tReference\tchr21\t41972615\tForward\tm41327/11677/CCS\n"
+        "BND: Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm21263/13017/CCS\n"
+        "BND: Reference\tchr22\t17458418\tForward\tReference\tchr21\t41972616\tForward\tm38637/7161/CCS\n"
+        "Start clustering...\n"
+        "Done with clustering. Found 4 junction clusters.\n"
+        "No refinement was selected.\n"
+    };
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_EQ(result.out, expected_res);
     EXPECT_EQ(result.err, expected_err);
 }
 

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -277,7 +277,6 @@ TEST_F(iGenVar_cli_test, test_direct_methods_input)
     EXPECT_EQ(result.err, expected_err_default_no_err);
 }
 
-//TODO (irallia): This should get a better Error message with resolving https://github.com/seqan/seqan3/issues/2464
 TEST_F(iGenVar_cli_test, test_unknown_argument)
 {
     cli_test_result result = execute_app("iGenVar",
@@ -285,7 +284,8 @@ TEST_F(iGenVar_cli_test, test_unknown_argument)
                                          "-m 9");
     std::string expected_err
     {
-        "[Error] Value parse failed for -m: Argument 9 could not be parsed as type std::string.\n"
+        "[Error] You have chosen an invalid input value: 9. "
+        "Please use one of: [read_depth,3,read_pairs,2,split_read,1,cigar_string,0]\n"
     };
     EXPECT_EQ(result.exit_code, 65280);
     EXPECT_EQ(result.out, std::string{});


### PR DESCRIPTION
Resolves #78 

Update EnumValidator such that `args.methods` (detection_methods) can be used and give a nice help page view.

EDIT (22.03.2021): We should probably wait for https://github.com/seqan/seqan3/issues/2464 and update the seqan3 library.
EDIT (06.04.2021): We also want to wait for https://github.com/seqan/seqan3/pull/2502 to avoid another seqan3 version change.
EDIT (07.04.2021): Both seqan PRs are merged now. This PR can get merged after the reviews.