### PR TITLE
[TEST] add more API tests

### DIFF
--- a/include/structures/aligned_segment.hpp
+++ b/include/structures/aligned_segment.hpp
@@ -47,4 +47,18 @@ inline constexpr stream_t operator<<(stream_t && stream, AlignedSegment const & 
     return stream;
 }
 
+/*! \brief An aligned segment is smaller than another, if their query start, 
+ *         query end, or mapping quality (in this order) is smaller than
+ *         the corresponding element of the other aligned segment.
+ *
+ * \param lhs - left side aligned segment
+ * \param rhs - right side aligned segment
+ */
 bool operator<(AlignedSegment const & lhs, AlignedSegment const & rhs);
+
+/*! \brief An aligned segment is equal to another, if all their members are equal.
+ *
+ * \param lhs - left side aligned segment
+ * \param rhs - right side aligned segment
+ */
+bool operator==(AlignedSegment const & lhs, AlignedSegment const & rhs);

--- a/include/structures/cluster.hpp
+++ b/include/structures/cluster.hpp
@@ -66,3 +66,14 @@ inline stream_t operator<<(stream_t && stream, Cluster const & clust)
  * \param rhs   right side cluster
  */
 bool operator<(Cluster const & lhs, Cluster const & rhs);
+
+/*! \brief A cluster is equal to another, if both have the same member junctions.
+ *         The member junctions need to have the same mates and inserted sequences.
+ *         The definition of equality implemented here is very strict because it
+ *         contains the cluster members instead of the average mates only.
+ *         It may happen that for two clusters a and b neither a<b, b<a nor a==b is true.
+ *
+ * \param lhs - left side cluster
+ * \param rhs - right side cluster
+ */
+bool operator==(Cluster const & lhs, Cluster const & rhs);

--- a/src/modules/sv_detection_methods/analyze_cigar_method.cpp
+++ b/src/modules/sv_detection_methods/analyze_cigar_method.cpp
@@ -37,7 +37,7 @@ void analyze_cigar(std::string const & read_name,
             {
                 // Insertions cause one junction from the insertion location to the next base
                 auto inserted_bases = query_sequence | seqan3::views::slice(pos_read, pos_read + length);
-                Junction new_junction{Breakend{chromosome, pos_ref-1, strand::forward},
+                Junction new_junction{Breakend{chromosome, pos_ref - 1, strand::forward},
                                       Breakend{chromosome, pos_ref, strand::forward},
                                       inserted_bases,
                                       read_name};
@@ -51,7 +51,7 @@ void analyze_cigar(std::string const & read_name,
             if (length >= min_length)
             {
                 // Deletions cause one junction from its start to its end
-                Junction new_junction{Breakend{chromosome, pos_ref, strand::forward},
+                Junction new_junction{Breakend{chromosome, pos_ref - 1, strand::forward},
                                       Breakend{chromosome, pos_ref + length, strand::forward},
                                       ""_dna5,
                                       read_name};

--- a/src/structures/aligned_segment.cpp
+++ b/src/structures/aligned_segment.cpp
@@ -137,3 +137,12 @@ bool operator<(AlignedSegment const & lhs, AlignedSegment const & rhs)
                 ? lhs.get_query_end() < rhs.get_query_end()
                 : lhs.mapq < rhs.mapq;
 }
+
+bool operator==(AlignedSegment const & lhs, AlignedSegment const & rhs)
+{
+    return lhs.orientation == rhs.orientation &&
+           lhs.ref_name == rhs.ref_name &&
+           lhs.pos == rhs.pos &&
+           lhs.mapq == rhs.mapq &&
+           lhs.cig == rhs.cig;
+}

--- a/src/structures/cluster.cpp
+++ b/src/structures/cluster.cpp
@@ -95,3 +95,12 @@ bool operator<(Cluster const & lhs, Cluster const & rhs)
             ? lhs.get_average_mate2() < rhs.get_average_mate2()
             : lhs.get_average_inserted_sequence_size() < rhs.get_average_inserted_sequence_size();
 }
+
+bool operator==(Cluster const & lhs, Cluster const & rhs)
+{
+    std::vector<Junction> lhs_members = lhs.get_members();
+    std::sort(lhs_members.begin(), lhs_members.end());
+    std::vector<Junction> rhs_members = rhs.get_members();
+    std::sort(rhs_members.begin(), rhs_members.end());
+    return (lhs_members == rhs_members);
+}

--- a/src/structures/cluster.cpp
+++ b/src/structures/cluster.cpp
@@ -90,10 +90,10 @@ std::vector<Junction> Cluster::get_members() const
 bool operator<(Cluster const & lhs, Cluster const & rhs)
 {
     return lhs.get_average_mate1() != rhs.get_average_mate1()
-        ? lhs.get_average_mate1() < rhs.get_average_mate1()
-        : lhs.get_average_mate2() != rhs.get_average_mate2()
-            ? lhs.get_average_mate2() < rhs.get_average_mate2()
-            : lhs.get_average_inserted_sequence_size() < rhs.get_average_inserted_sequence_size();
+           ? lhs.get_average_mate1() < rhs.get_average_mate1()
+           : lhs.get_average_mate2() != rhs.get_average_mate2()
+              ? lhs.get_average_mate2() < rhs.get_average_mate2()
+              : lhs.get_average_inserted_sequence_size() < rhs.get_average_inserted_sequence_size();
 }
 
 bool operator==(Cluster const & lhs, Cluster const & rhs)

--- a/src/structures/junction.cpp
+++ b/src/structures/junction.cpp
@@ -23,10 +23,10 @@ std::string Junction::get_read_name() const
 bool operator<(Junction const & lhs, Junction const & rhs)
 {
     return lhs.get_mate1() != rhs.get_mate1()
-        ? lhs.get_mate1() < rhs.get_mate1()
-        : lhs.get_mate2() != rhs.get_mate2()
-            ? lhs.get_mate2() < rhs.get_mate2()
-            : lhs.get_inserted_sequence() < rhs.get_inserted_sequence();
+           ? lhs.get_mate1() < rhs.get_mate1()
+           : lhs.get_mate2() != rhs.get_mate2()
+             ? lhs.get_mate2() < rhs.get_mate2()
+             : lhs.get_inserted_sequence() < rhs.get_inserted_sequence();
 }
 
 bool operator==(Junction const & lhs, Junction const & rhs)

--- a/test/api/clustering_test.cpp
+++ b/test/api/clustering_test.cpp
@@ -28,21 +28,21 @@ std::vector<Junction> prepare_input_junctions()
     std::vector<Junction> input_junctions
     {
         Junction{Breakend{chrom1, chrom1_position1 - 5, strand::forward},
-                 Breakend{chrom2, chrom2_position1 + 8, strand::forward}, ""_dna5, read_name_1}, //cluster 1
+                 Breakend{chrom2, chrom2_position1 + 8, strand::forward}, ""_dna5, read_name_1},
         Junction{Breakend{chrom1, chrom1_position1 + 2, strand::forward},
-                 Breakend{chrom2, chrom2_position1 - 3, strand::forward}, ""_dna5, read_name_2}, //cluster 1
+                 Breakend{chrom2, chrom2_position1 - 3, strand::forward}, ""_dna5, read_name_2},
         Junction{Breakend{chrom1, chrom1_position1 + 9, strand::forward},
-                 Breakend{chrom2, chrom2_position1 + 1, strand::forward}, ""_dna5, read_name_3}, //cluster 1
+                 Breakend{chrom2, chrom2_position1 + 1, strand::forward}, ""_dna5, read_name_3},
         Junction{Breakend{chrom1, chrom1_position1 + 5, strand::forward},
-                 Breakend{chrom2, chrom2_position1 - 1, strand::reverse}, ""_dna5, read_name_4}, //cluster 2
+                 Breakend{chrom2, chrom2_position1 - 1, strand::reverse}, ""_dna5, read_name_4},
         Junction{Breakend{chrom1, chrom1_position1 + 92, strand::forward},
-                 Breakend{chrom2, chrom2_position1 + 3, strand::forward}, ""_dna5, read_name_5}, //cluster 3
+                 Breakend{chrom2, chrom2_position1 + 3, strand::forward}, ""_dna5, read_name_5},
         Junction{Breakend{chrom1, chrom1_position2 - 2, strand::forward},
-                 Breakend{chrom2, chrom1_position3 + 8, strand::reverse}, ""_dna5, read_name_6}, //cluster 4
+                 Breakend{chrom2, chrom1_position3 + 8, strand::reverse}, ""_dna5, read_name_6},
         Junction{Breakend{chrom1, chrom1_position2 + 3, strand::forward},
-                 Breakend{chrom2, chrom1_position3 - 1, strand::reverse}, ""_dna5, read_name_7}, //cluster 4
+                 Breakend{chrom2, chrom1_position3 - 1, strand::reverse}, ""_dna5, read_name_7},
         Junction{Breakend{chrom1, chrom1_position2 + 6, strand::forward},
-                 Breakend{chrom2, chrom1_position3 + 2, strand::reverse}, ""_dna5, read_name_8} //cluster 4
+                 Breakend{chrom2, chrom1_position3 + 2, strand::reverse}, ""_dna5, read_name_8}
     };
 
     std::sort(input_junctions.begin(), input_junctions.end());

--- a/test/api/clustering_test.cpp
+++ b/test/api/clustering_test.cpp
@@ -8,19 +8,6 @@ using seqan3::operator""_dna5;
 
 /* -------- clustering methods tests -------- */
 
-TEST(clustering, clustering_method_simple)
-{
-    testing::internal::CaptureStdout();
-
-    std::vector<Junction> junctions{};
-    std::vector<Cluster> resulting_clusters{};
-    resulting_clusters = simple_clustering_method(junctions);
-
-    std::vector<Cluster> expected_clusters{};
-    // TODO (irallia): We need to implement operator== for Clusters.
-    // EXPECT_EQ(expected_clusters, resulting_clusters);
-}
-
 std::string const chrom1 = "chr1";
 int32_t const chrom1_position1 = 12323443;
 int32_t const chrom1_position2 = 94734377;
@@ -62,6 +49,49 @@ std::vector<Junction> prepare_input_junctions()
     return input_junctions;
 }
 
+TEST(clustering, clustering_method_simple)
+{
+    std::vector<Junction> input_junctions = prepare_input_junctions();
+    std::vector<Cluster> resulting_clusters{};
+    resulting_clusters = simple_clustering_method(input_junctions);
+
+    // Each junction in separate cluster
+    std::vector<Cluster> expected_clusters
+    {
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position1 - 5, strand::forward},
+                             Breakend{chrom2, chrom2_position1 + 8, strand::forward}, ""_dna5, read_name_1}
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position1 + 2, strand::forward},
+                             Breakend{chrom2, chrom2_position1 - 3, strand::forward}, ""_dna5, read_name_2}
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position1 + 9, strand::forward},
+                             Breakend{chrom2, chrom2_position1 + 1, strand::forward}, ""_dna5, read_name_3},
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position1 + 5, strand::forward},
+                             Breakend{chrom2, chrom2_position1 - 1, strand::reverse}, ""_dna5, read_name_4},
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position1 + 92, strand::forward},
+                             Breakend{chrom2, chrom2_position1 + 3, strand::forward}, ""_dna5, read_name_5},
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position2 - 2, strand::forward},
+                             Breakend{chrom2, chrom1_position3 + 8, strand::reverse}, ""_dna5, read_name_6}
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position2 + 3, strand::forward},
+                             Breakend{chrom2, chrom1_position3 - 1, strand::reverse}, ""_dna5, read_name_7}
+        }},
+        Cluster{{   Junction{Breakend{chrom1, chrom1_position2 + 6, strand::forward},
+                             Breakend{chrom2, chrom1_position3 + 2, strand::reverse}, ""_dna5, read_name_8}
+        }}
+    };
+    std::sort(expected_clusters.begin(), expected_clusters.end());
+
+    ASSERT_EQ(expected_clusters.size(), resulting_clusters.size());
+
+    for (size_t cluster_index = 0; cluster_index < expected_clusters.size(); ++cluster_index)
+    {
+        EXPECT_TRUE(expected_clusters[cluster_index] == resulting_clusters[cluster_index]) << "Cluster " << cluster_index << " unequal";
+    }
+}
 
 TEST(clustering, partitioning)
 {

--- a/test/api/detection_test.cpp
+++ b/test/api/detection_test.cpp
@@ -173,7 +173,8 @@ TEST(junction_detection, split_string)
 
 TEST(junction_detection, retrieve_aligned_segments)
 {
-    std::string const sa_tag = "chr1,100,+,6M44S,60,0;chr2,100,+,6S10M34S,60,0;chr1,106,+,16S10M24S,60,0;chr1,116,-,10S14M26S,60,0;chr1,130,+,40S4M6S,60,0;chr1,150,+,44S6M,60,0;";
+    std::string const sa_tag = "chr1,100,+,6M44S,60,0;chr2,100,+,6S10M34S,60,0;chr1,106,+,16S10M24S,60,0;"
+                               "chr1,116,-,10S14M26S,60,0;chr1,130,+,40S4M6S,60,0;chr1,150,+,44S6M,60,0;";
     std::vector<AlignedSegment> segments_res{};
     retrieve_aligned_segments(sa_tag, segments_res);
 
@@ -280,7 +281,8 @@ TEST(junction_detection, analyze_sa_tag)
     std::vector<seqan3::cigar> cigar_string = {{10, 'S'_cigar_operation}, {14, 'M'_cigar_operation}, {26, 'S'_cigar_operation}};
     seqan3::dna5_vector seq = {"GGGCTCATCGATCGATTTCGGATCGGGGGGCCCCCATTTTAAACGGCCCC"_dna5};
     // Supplementary alignments
-    std::string const sa_tag = "chr1,100,+,6M44S,60,0;chr2,100,+,6S10M34S,60,0;chr1,106,+,16S10M24S,60,0;chr1,116,-,10S14M26S,60,0;chr1,130,+,40S4M6S,60,0;chr1,150,+,44S6M,60,0;";
+    std::string const sa_tag = "chr1,100,+,6M44S,60,0;chr2,100,+,6S10M34S,60,0;chr1,106,+,16S10M24S,60,0;"
+                               "chr1,116,-,10S14M26S,60,0;chr1,130,+,40S4M6S,60,0;chr1,150,+,44S6M,60,0;";
     std::vector<Junction> junctions_res{};
     analyze_sa_tag(read_name, flag, chromosome, pos, mapq, cigar_string, seq, sa_tag, junctions_res);
 

--- a/test/api/detection_test.cpp
+++ b/test/api/detection_test.cpp
@@ -138,7 +138,38 @@ TEST(junction_detection, cigar_string_ins_hardclip)
     }
 }
 
-TEST(junction_detection, split_read_method_simple)
+TEST(junction_detection, split_string)
+{
+    std::vector<std::string> test_strings{"a;a;a;aa", "b,  b,b,  bbb", "c c cccc", ";d;;d;"};
+    {
+        std::vector<std::string> resulting_strings{};
+        split_string(test_strings[0], resulting_strings, ';');      // split "a;a;a;aa"     with ';'
+        std::vector<std::string> expected{"a", "a", "a", "aa"};
+        EXPECT_EQ(expected, resulting_strings);
+    }
+    {
+        std::vector<std::string> resulting_strings{};
+        split_string(test_strings[1], resulting_strings, ',');      // split "b,  b,b,  bbb" with ','
+        std::vector<std::string> expected{ "b", "  b", "b", "  bbb" };
+        EXPECT_EQ(expected, resulting_strings);
+    }
+    {
+        std::vector<std::string> resulting_strings1{};
+        split_string(test_strings[2], resulting_strings1, ' ');     // split "c c cccc"     with ' '
+        std::vector<std::string> expected{"c", "c", "cccc"};
+        EXPECT_EQ(expected, resulting_strings1);
+
+        std::vector<std::string> resulting_strings2{};
+        split_string(test_strings[2], resulting_strings2);          // split "c c cccc"     with default ' '
+        EXPECT_EQ(resulting_strings1, resulting_strings2);
+    }
+    {
+        std::vector<std::string> resulting_strings{};
+        split_string(test_strings[3], resulting_strings, ';');      // split ";d;;d;" with ';'
+        std::vector<std::string> expected{ "", "d", "", "d" };
+        EXPECT_EQ(expected, resulting_strings);
+    }
+}
 {
     std::string const read_name = "read021";
     seqan3::sam_flag const flag{0u};

--- a/test/api/detection_test.cpp
+++ b/test/api/detection_test.cpp
@@ -170,6 +170,43 @@ TEST(junction_detection, split_string)
         EXPECT_EQ(expected, resulting_strings);
     }
 }
+
+TEST(junction_detection, retrieve_aligned_segments)
+{
+    std::string const sa_tag = "chr1,100,+,6M44S,60,0;chr2,100,+,6S10M34S,60,0;chr1,106,+,16S10M24S,60,0;chr1,116,-,10S14M26S,60,0;chr1,130,+,40S4M6S,60,0;chr1,150,+,44S6M,60,0;";
+    std::vector<AlignedSegment> segments_res{};
+    retrieve_aligned_segments(sa_tag, segments_res);
+
+    AlignedSegment aligned_segment1 {strand::forward, "chr1", 100, 60, std::vector<seqan3::cigar>{{6, 'M'_cigar_operation},
+                                                                                                  {44, 'S'_cigar_operation}}};
+    AlignedSegment aligned_segment2 {strand::forward, "chr2", 100, 60, std::vector<seqan3::cigar>{{6, 'S'_cigar_operation},
+                                                                                                  {10, 'M'_cigar_operation},
+                                                                                                  {34, 'S'_cigar_operation}}};
+    AlignedSegment aligned_segment3 {strand::forward, "chr1", 106, 60, std::vector<seqan3::cigar>{{16, 'S'_cigar_operation},
+                                                                                                  {10, 'M'_cigar_operation},
+                                                                                                  {24, 'S'_cigar_operation}}};
+    AlignedSegment aligned_segment4 {strand::reverse, "chr1", 116, 60, std::vector<seqan3::cigar>{{10, 'S'_cigar_operation},
+                                                                                                  {14, 'M'_cigar_operation},
+                                                                                                  {26, 'S'_cigar_operation}}};
+    AlignedSegment aligned_segment5 {strand::forward, "chr1", 130, 60, std::vector<seqan3::cigar>{{40, 'S'_cigar_operation},
+                                                                                                  {4, 'M'_cigar_operation},
+                                                                                                  {6, 'S'_cigar_operation}}};
+    AlignedSegment aligned_segment6 {strand::forward, "chr1", 150, 60, std::vector<seqan3::cigar>{{44, 'S'_cigar_operation},
+                                                                                                  {6, 'M'_cigar_operation}}};
+    std::vector<AlignedSegment> segments_expected_res{aligned_segment1,
+                                                      aligned_segment2,
+                                                      aligned_segment3,
+                                                      aligned_segment4,
+                                                      aligned_segment5,
+                                                      aligned_segment6};
+
+    ASSERT_EQ(segments_expected_res.size(), segments_res.size());
+
+    for (size_t i = 0; i < segments_expected_res.size(); ++i)
+    {
+        EXPECT_TRUE(segments_expected_res[i] == segments_res[i]);
+    }
+}
 {
     std::string const read_name = "read021";
     seqan3::sam_flag const flag{0u};

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -19,4 +19,4 @@ declare_datasource (FILE mini_example.sam
 # copies file to <build>/data/output_err.txt
 declare_datasource (FILE output_err.txt
                     URL ${CMAKE_SOURCE_DIR}/test/data/mini_example/output_err.txt
-                    URL_HASH SHA256=10ff325f4997b8dee4bb845df92a5949b770f1574ad8022ef7761d1401f45ed8)
+                    URL_HASH SHA256=6ed07cf582be4d355629d2143c7fcf4171db97ad1a68630466c362559a427641)

--- a/test/data/mini_example/output_err.txt
+++ b/test/data/mini_example/output_err.txt
@@ -1,23 +1,23 @@
-DEL: chr1	57	Forward	chr1	70	Forward	0	read010
-DEL: chr1	57	Forward	chr1	70	Forward	0	read011
-DEL: chr1	57	Forward	chr1	70	Forward	0	read012
-DEL: chr1	57	Forward	chr1	70	Forward	0	read013
-DEL: chr1	57	Forward	chr1	70	Forward	0	read014
-DEL: chr1	57	Forward	chr1	70	Forward	0	read015
-DEL: chr1	57	Forward	chr1	70	Forward	0	read016
-DEL: chr1	57	Forward	chr1	70	Forward	0	read017
-DEL: chr1	57	Forward	chr1	70	Forward	0	read018
+DEL: chr1	56	Forward	chr1	70	Forward	0	read010
+DEL: chr1	56	Forward	chr1	70	Forward	0	read011
+DEL: chr1	56	Forward	chr1	70	Forward	0	read012
+DEL: chr1	56	Forward	chr1	70	Forward	0	read013
+DEL: chr1	56	Forward	chr1	70	Forward	0	read014
+DEL: chr1	56	Forward	chr1	70	Forward	0	read015
+DEL: chr1	56	Forward	chr1	70	Forward	0	read016
+DEL: chr1	56	Forward	chr1	70	Forward	0	read017
+DEL: chr1	56	Forward	chr1	70	Forward	0	read018
 INS: chr1	124	Forward	chr1	125	Forward	15	read023
 INS: chr1	124	Forward	chr1	125	Forward	15	read024
 INS: chr1	124	Forward	chr1	125	Forward	15	read025
 INS: chr1	179	Forward	chr1	180	Forward	8	read031
-DEL: chr1	266	Forward	chr1	286	Forward	0	read037
-DEL: chr1	266	Forward	chr1	286	Forward	0	read038
-DEL: chr1	282	Forward	chr1	299	Forward	0	read041
-DEL: chr1	336	Forward	chr1	350	Forward	0	read042
-DEL: chr1	336	Forward	chr1	350	Forward	0	read043
-DEL: chr1	336	Forward	chr1	350	Forward	0	read044
-DEL: chr1	336	Forward	chr1	350	Forward	0	read045
+DEL: chr1	265	Forward	chr1	286	Forward	0	read037
+DEL: chr1	265	Forward	chr1	286	Forward	0	read038
+DEL: chr1	281	Forward	chr1	299	Forward	0	read041
+DEL: chr1	335	Forward	chr1	350	Forward	0	read042
+DEL: chr1	335	Forward	chr1	350	Forward	0	read043
+DEL: chr1	335	Forward	chr1	350	Forward	0	read044
+DEL: chr1	335	Forward	chr1	350	Forward	0	read045
 Start clustering...
 Done with clustering. Found 6 junction clusters.
 No refinement was selected.


### PR DESCRIPTION
This PR fixes #12 by adding additional API tests for the following methods:

File: src/modules/sv_detection_methods/analyze_sa_tag_method.cpp
- [x] `split_string()`
- [x] `retrieve_aligned_segments()`
- [x] `analyze_aligned_segments()`
- [x] `analyze_sa_tag()`

File: src/modules/sv_detection_methods/analyze_cigar_method.cpp
- [x] `analyze_cigar()`

File: src/modules/clustering/simple_clustering_method.cpp
- [x] `simple_clustering_method()`