### PR TITLE
[FEATURE] Correct and improve vcf output (insertion calling 2/2)

### DIFF
--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -13,6 +13,8 @@ struct cmd_arguments
     clustering_methods clustering_method{simple_clustering};                                    // default: simple clustering method
     refinement_methods refinement_method{no_refinement};                                        // default: no refinement
     uint64_t min_var_length = 30;
+    uint64_t max_var_length = 1000000;
+    uint64_t max_tol_inserted_length = 5;
 };
 
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args);
@@ -35,7 +37,9 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
  *                      (0: no_refinement,
  *                       1: sViper_refinement_method,
  *                       2: sVirl_refinement_method) - *default: no refinement*\n
- *                   **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*
+ *                   **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*\n
+ *                   **args.max_var_length** - maximum length of variants to detect - *default: 1,000,000 bp*\n
+ *                   **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types - *default: 5 bp*
  *
  *
  * \details Detects novel junctions from read alignment records using different detection methods.

--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -2,7 +2,18 @@
 
 #include <seqan3/argument_parser/argument_parser.hpp>   // for seqan3::argument_parser
 
-struct cmd_arguments;
+#include "variant_detection/method_enums.hpp"           // for enum detection_methods, clustering_methods and refinement_methods
+
+struct cmd_arguments
+{
+    std::filesystem::path alignment_short_reads_file_path{""};
+    std::filesystem::path alignment_long_reads_file_path{""};
+    std::filesystem::path output_file_path{};
+    std::vector<detection_methods> methods{cigar_string, split_read, read_pairs, read_depth};   // default: all methods
+    clustering_methods clustering_method{simple_clustering};                                    // default: simple clustering method
+    refinement_methods refinement_method{no_refinement};                                        // default: no refinement
+    uint64_t min_var_length = 30;
+};
 
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args);
 

--- a/include/variant_detection/variant_output.hpp
+++ b/include/variant_detection/variant_output.hpp
@@ -12,10 +12,13 @@
  *
  * \param[in]       clusters    - input junction clusters
  * \param[in]       args        - command line arguments:\n
- *                                **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*
+ *                                **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*\n
+ *                                **args.max_var_length** - maximum length of variants to detect - *default: 1,000,000 bp*\n
+ *                                **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types - *default: 5 bp*
  * \param[in, out]  out_stream  - output stream
  *
  * \details Extracts genomic variants from given junction clusters.
+ *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the SV).
  */
 void find_and_output_variants(std::vector<Cluster> const & clusters,
                               cmd_arguments const & args,
@@ -26,10 +29,13 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
  *
  * \param[in] clusters          - input junction clusters
  * \param[in] args              - command line arguments:\n
- *                                **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*
+ *                                **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*\n
+ *                                **args.max_var_length** - maximum length of variants to detect - *default: 1,000,000 bp*\n
+ *                                **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types - *default: 5 bp*
  * \param[in] output_file_path  - output file path
  *
  * \details Extracts genomic variants from given junction clusters.
+ *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the SV).
  */
 //!\overload
 void find_and_output_variants(std::vector<Cluster> const & clusters,

--- a/include/variant_detection/variant_output.hpp
+++ b/include/variant_detection/variant_output.hpp
@@ -4,26 +4,34 @@
 
 #include <seqan3/std/filesystem>
 
-#include "structures/cluster.hpp"     // for class Cluster
+#include "iGenVar.hpp"              // for cmd_arguments
+#include "structures/cluster.hpp"   // for class Cluster
 
 
 /*! \brief Detects genomic variants from junction clusters and prints them to output stream in VCF format.
  *
  * \param[in]       clusters    - input junction clusters
+ * \param[in]       args        - command line arguments:\n
+ *                                **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*
  * \param[in, out]  out_stream  - output stream
  *
  * \details Extracts genomic variants from given junction clusters.
  */
-void find_and_output_variants(std::vector<Cluster> const & clusters, std::ostream & out_stream);
+void find_and_output_variants(std::vector<Cluster> const & clusters,
+                              cmd_arguments const & args,
+                              std::ostream & out_stream);
 
 
 /*! \brief Detects genomic variants from junction clusters and prints them in output file in VCF format.
  *
  * \param[in] clusters          - input junction clusters
+ * \param[in] args              - command line arguments:\n
+ *                                **args.min_var_length** - minimum length of variants to detect - *default: 30 bp*
  * \param[in] output_file_path  - output file path
  *
  * \details Extracts genomic variants from given junction clusters.
  */
 //!\overload
 void find_and_output_variants(std::vector<Cluster> const & clusters,
-                             std::filesystem::path const & output_file_path);
+                              cmd_arguments const & args,
+                              std::filesystem::path const & output_file_path);

--- a/include/variant_parser/variant_record.hpp
+++ b/include/variant_parser/variant_record.hpp
@@ -82,7 +82,7 @@ public:
                        << ",Description=\"" << i.description << "\",Source=\"" << i.source << "\",Version=\""
                        << i.version << "\">" << '\n';
         }
-        out_stream << "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" << '\n';
+        out_stream << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" << '\n';
     }
 
 private:

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -132,7 +132,7 @@ void detect_variants_in_alignment_file(cmd_arguments const & args)
             break;
     }
 
-    find_and_output_variants(clusters, args.output_file_path);
+    find_and_output_variants(clusters, args, args.output_file_path);
 }
 
 int main(int argc, char ** argv)

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -9,17 +9,6 @@
 #include "variant_detection/variant_detection.hpp"                  // for detect_junctions_in_long_reads_sam_file()
 #include "variant_detection/variant_output.hpp"                     // for find_and_output_variants()
 
-struct cmd_arguments
-{
-    std::filesystem::path alignment_short_reads_file_path{""};
-    std::filesystem::path alignment_long_reads_file_path{""};
-    std::filesystem::path output_file_path{};
-    std::vector<detection_methods> methods{cigar_string, split_read, read_pairs, read_depth};   // default: all methods
-    clustering_methods clustering_method{simple_clustering};                                    // default: simple clustering method
-    refinement_methods refinement_method{no_refinement};                                        // default: no refinement
-    uint64_t min_var_length = 30;
-};
-
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Lydia Buntrock, David Heller, Joshua Kim";

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -58,6 +58,13 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
     parser.add_option(args.min_var_length, 'l', "min_var_length",
                       "Specify what should be the minimum length of your SVs to be detected (default 30 bp).",
                       seqan3::option_spec::advanced);
+    parser.add_option(args.max_var_length, 'x', "max_var_length",
+                      "Specify what should be the maximum length of your SVs to be detected (default 1,000,000 bp). "
+                      "SVs larger than this threshold can still be output as translocations.",
+                      seqan3::option_spec::advanced);
+    parser.add_option(args.max_tol_inserted_length, 't', "max_tol_inserted_length",
+                      "Specify what should be the longest tolerated inserted sequence at sites of non-INS SVs (default 5 bp).",
+                      seqan3::option_spec::advanced);
 }
 
 void detect_variants_in_alignment_file(cmd_arguments const & args)

--- a/src/variant_detection/variant_output.cpp
+++ b/src/variant_detection/variant_output.cpp
@@ -32,8 +32,8 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
                     int32_t distance = mate2_pos - mate1_pos;
                     //Deletion
                     if (distance >= args.min_var_length &&
-                        distance < 1000000 &&
-                        insert_size < 5)
+                        distance <= args.max_var_length &&
+                        insert_size <= args.max_tol_inserted_length)
                     {
                         variant_record tmp{};
                         tmp.set_chrom(mate1.seq_name);

--- a/src/variant_detection/variant_output.cpp
+++ b/src/variant_detection/variant_output.cpp
@@ -19,6 +19,7 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
     {
         Breakend mate1 = clusters[i].get_average_mate1();
         Breakend mate2 = clusters[i].get_average_mate2();
+        size_t cluster_size = clusters[i].get_cluster_size();
         if (mate1.orientation == mate2.orientation)
         {
             if (mate1.seq_name == mate2.seq_name)
@@ -36,11 +37,14 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
                     {
                         variant_record tmp{};
                         tmp.set_chrom(mate1.seq_name);
-                        tmp.set_qual(60);
+                        tmp.set_qual(cluster_size);
                         tmp.set_alt("<DEL>");
                         tmp.add_info("SVTYPE", "DEL");
-                        tmp.set_pos(mate1_pos);
-                        tmp.add_info("SVLEN", std::to_string(-distance));
+                        // Increment position by 1 because VCF is 1-based
+                        tmp.set_pos(mate1_pos + 1);
+                        tmp.add_info("SVLEN", std::to_string(-distance + 1));
+                        // Increment end by 1 because VCF is 1-based
+                        // Decrement end by 1 because deletion ends one base before mate2 begins
                         tmp.add_info("END", std::to_string(mate2_pos));
                         tmp.print(out_stream);
                     }
@@ -50,12 +54,14 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
                     {
                         variant_record tmp{};
                         tmp.set_chrom(mate1.seq_name);
-                        tmp.set_qual(60);
+                        tmp.set_qual(cluster_size);
                         tmp.set_alt("<INS>");
                         tmp.add_info("SVTYPE", "INS");
-                        tmp.set_pos(mate1_pos);
+                        // Increment position by 1 because VCF is 1-based
+                        tmp.set_pos(mate1_pos + 1);
                         tmp.add_info("SVLEN", std::to_string(insert_size));
-                        tmp.add_info("END", std::to_string(mate1_pos));
+                        // Increment end by 1 because VCF is 1-based
+                        tmp.add_info("END", std::to_string(mate1_pos + 1));
                         tmp.print(out_stream);
                     }
                 }

--- a/src/variant_detection/variant_output.cpp
+++ b/src/variant_detection/variant_output.cpp
@@ -4,7 +4,9 @@
 #include "variant_detection/variant_output.hpp"
 #include "variant_parser/variant_record.hpp"    // for class variant_header
 
-void find_and_output_variants(std::vector<Cluster> const & clusters, std::ostream & out_stream)
+void find_and_output_variants(std::vector<Cluster> const & clusters,
+                              cmd_arguments const & args,
+                              std::ostream & out_stream)
 {
     variant_header header{};
     header.set_fileformat("VCFv4.3");
@@ -61,11 +63,12 @@ void find_and_output_variants(std::vector<Cluster> const & clusters, std::ostrea
 
 //!\overload
 void find_and_output_variants(std::vector<Cluster> const & clusters,
-                             std::filesystem::path const & output_file_path)
+                              cmd_arguments const & args,
+                              std::filesystem::path const & output_file_path)
 {
     if (output_file_path.empty())
     {
-        find_and_output_variants(clusters, std::cout);
+        find_and_output_variants(clusters, args, std::cout);
     }
     else
     {
@@ -74,7 +77,7 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
         {
             throw std::runtime_error{"Could not open file '" + output_file_path.string() + "' for reading."};
         }
-        find_and_output_variants(clusters, out_file);
+        find_and_output_variants(clusters, args, out_file);
         out_file.close();
     }
 }

--- a/test/cli/CMakeLists.txt
+++ b/test/cli/CMakeLists.txt
@@ -5,6 +5,7 @@ add_dependencies (iGenVar_cli_test "iGenVar")
 target_use_datasources (iGenVar_cli_test FILES simulated.minimap2.hg19.coordsorted_cutoff.sam)
 target_use_datasources (iGenVar_cli_test FILES paired_end_mini_example.sam)
 target_use_datasources (iGenVar_cli_test FILES single_end_mini_example.sam)
+target_use_datasources (iGenVar_cli_test FILES output_res.txt)
 target_use_datasources (iGenVar_cli_test FILES output_err.txt)
 
 # add_cli_test (iGenVar_options_test.cpp)

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -98,6 +98,17 @@ std::string expected_res_default
     "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+    "chr21\t41972615\t.\tN\t<INS>\t60\tPASS\tEND=41972615;SVLEN=1681;SVTYPE=INS\n"
+};
+
+std::string expected_res_empty
+{
+    "##fileformat=VCFv4.3\n"
+    "##source=iGenVarCaller\n"
+    "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+    "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+    "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
 };
 
 std::string expected_err_default_no_err
@@ -298,7 +309,7 @@ TEST_F(iGenVar_cli_test, dataset_paired_end_mini_example)
 
     // Check the output of junctions:
     seqan3::debug_stream << "Check the output of junctions... " << '\n';
-    EXPECT_EQ(result.out, expected_res_default);
+    EXPECT_EQ(result.out, expected_res_empty);
     seqan3::debug_stream << "done. " << '\n';
 
     // Check the debug output of junctions:
@@ -358,9 +369,9 @@ TEST_F(iGenVar_cli_test, dataset_single_end_mini_example)
                                          "-l 8 -m 0 -m 1");
 
     // Check the output of junctions:
-    seqan3::debug_stream << "Check the output of junctions... " << '\n';
-    EXPECT_EQ(result.out, expected_res_default);
-    seqan3::debug_stream << "done. " << '\n';
+    // seqan3::debug_stream << "Check the output of junctions... " << '\n';
+    // EXPECT_EQ(result.out, expected_res_default);
+    // seqan3::debug_stream << "done. " << '\n';
 
     // Check the debug output of junctions:
     seqan3::debug_stream << "Check the debug output of junctions... " << '\n';

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -81,6 +81,13 @@ std::string const help_page_advanced
     "    -l, --min_var_length (unsigned 64 bit integer)\n"
     "          Specify what should be the minimum length of your SVs to be detected\n"
     "          (default 30 bp). Default: 30.\n"
+    "    -x, --max_var_length (unsigned 64 bit integer)\n"
+    "          Specify what should be the maximum length of your SVs to be detected\n"
+    "          (default 1,000,000 bp). SVs larger than this threshold can still be\n"
+    "          output as translocations. Default: 1000000.\n"
+    "    -t, --max_tol_inserted_length (unsigned 64 bit integer)\n"
+    "          Specify what should be the longest tolerated inserted sequence at\n"
+    "          sites of non-INS SVs (default 5 bp). Default: 5.\n"
 };
 
 // std::string expected_res_default
@@ -175,11 +182,11 @@ TEST_F(iGenVar_cli_test, fail_unknown_option)
 {
     cli_test_result result = execute_app("iGenVar",
                                          "-j", data(default_alignment_long_reads_file_path),
-                                         "-x 0");
+                                         "-y 0");
 
     std::string expected_err
     {
-        "[Error] Unknown option -x. In case this is meant to be a non-option/argument/parameter, please specify the "
+        "[Error] Unknown option -y. In case this is meant to be a non-option/argument/parameter, please specify the "
         "start of non-options with '--'. See -h/--help for program information.\n"
     };
     EXPECT_EQ(result.exit_code, 65280);

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -98,7 +98,7 @@ std::string expected_res_default
     "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
-    "chr21\t41972615\t.\tN\t<INS>\t60\tPASS\tEND=41972615;SVLEN=1681;SVTYPE=INS\n"
+    "chr21\t41972616\t.\tN\t<INS>\t1\tPASS\tEND=41972616;SVLEN=1681;SVTYPE=INS\n"
 };
 
 std::string expected_res_empty
@@ -369,15 +369,21 @@ TEST_F(iGenVar_cli_test, dataset_single_end_mini_example)
                                          "-l 8 -m 0 -m 1");
 
     // Check the output of junctions:
-    // seqan3::debug_stream << "Check the output of junctions... " << '\n';
-    // EXPECT_EQ(result.out, expected_res_default);
-    // seqan3::debug_stream << "done. " << '\n';
+    seqan3::debug_stream << "Check the output of junctions... " << '\n';
+    std::ifstream output_res_file("../../data/output_res.txt");
+    std::string output_res_str((std::istreambuf_iterator<char>(output_res_file)),
+                                std::istreambuf_iterator<char>());
+    //Todo(eldariont): Correct output_res.txt after merging #113:
+    //line 8: DEL should be at chr1:97-125 (SVLEN=-28)
+    //line 12: DEL should be at chr1:266-287 (SVLEN=-20) and merged with line 11
+    EXPECT_EQ(result.out, output_res_str);
+    seqan3::debug_stream << "done. " << '\n';
 
     // Check the debug output of junctions:
     seqan3::debug_stream << "Check the debug output of junctions... " << '\n';
-    std::ifstream txt_test_file("../../data/output_err.txt");
-    std::string txt_test_file_str((std::istreambuf_iterator<char>(txt_test_file)),
-                                   std::istreambuf_iterator<char>());
-    EXPECT_EQ(result.err, txt_test_file_str);
+    std::ifstream output_err_file("../../data/output_err.txt");
+    std::string output_err_str((std::istreambuf_iterator<char>(output_err_file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(result.err, output_err_str);
     seqan3::debug_stream << "done. " << '\n';
 }

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -97,7 +97,7 @@ std::string expected_res_default
     "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
-    "CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
 };
 
 std::string expected_err_default_no_err

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -25,3 +25,8 @@ declare_datasource (FILE single_end_mini_example.sam
 declare_datasource (FILE output_err.txt
                     URL ${CMAKE_SOURCE_DIR}/test/data/mini_example/output_err.txt
                     URL_HASH SHA256=544738433966289653e0af4896a7700ad86f3fa414d57227a3a43c87525bd86a)
+
+# copies file to <build>/data/output_res.txt
+declare_datasource (FILE output_res.txt
+                    URL ${CMAKE_SOURCE_DIR}/test/data/mini_example/output_res.txt
+                    URL_HASH SHA256=cb5d391e58a8ffecf3bed3470bfc2f62c40d490c9270c55832e16cbfe2a5bbb1)

--- a/test/data/mini_example/output_res.txt
+++ b/test/data/mini_example/output_res.txt
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.3
+##source=iGenVarCaller
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of SV called.",Source="iGenVarCaller",Version="1.0">
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of SV called.",Source="iGenVarCaller",Version="1.0">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of SV called.",Source="iGenVarCaller",Version="1.0">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	57	.	N	<DEL>	9	PASS	END=70;SVLEN=-13;SVTYPE=DEL
+chr1	99	.	N	<DEL>	1	PASS	END=125;SVLEN=-26;SVTYPE=DEL
+chr1	125	.	N	<INS>	3	PASS	END=125;SVLEN=15;SVTYPE=INS
+chr1	180	.	N	<INS>	1	PASS	END=180;SVLEN=8;SVTYPE=INS
+chr1	266	.	N	<DEL>	2	PASS	END=286;SVLEN=-20;SVTYPE=DEL
+chr1	267	.	N	<DEL>	2	PASS	END=287;SVLEN=-20;SVTYPE=DEL
+chr1	282	.	N	<DEL>	1	PASS	END=299;SVLEN=-17;SVTYPE=DEL
+chr1	336	.	N	<DEL>	4	PASS	END=350;SVLEN=-14;SVTYPE=DEL


### PR DESCRIPTION
This PR fixes #111 and adds the output of insertions into the VCF. Additionally, it correct several small errors in the VCF output and propagates the `min_var_length` parameter to the VCF output method.