### PR TITLE
[INFRA] Update coverage CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -29,7 +29,7 @@ jobs:
             cxx: "g++-10"
             cc: "gcc-10"
             build: coverage
-            build_type: Debug
+            build_type: Coverage
 
           # - name: "gcc11"
           #   cxx: "g++-11"
@@ -66,10 +66,7 @@ jobs:
           submodules: recursive
 
       - name: Add package source
-        run: |
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/ppa
-          sudo add-apt-repository --no-update --yes ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
+        run: bash ./src/lib/seqan3/.github/workflows/scripts/configure_apt.sh
 
       - name: Install CMake
         run: bash ./src/lib/seqan3/.github/workflows/scripts/install_cmake.sh
@@ -109,9 +106,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ../src -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DIGENVAR_CODE_COVERAGE=${{ matrix.build == 'coverage' && 'ON' || 'OFF' }}
+          cmake ../src -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
 
-      - name: Build application
+      - name: Build tests
         env:
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -121,26 +118,26 @@ jobs:
         run: |
           ccache -p || true
           cd build
-          make -k -j2
+          make -k -j2 api_test cli_test
           ccache -s || true
 
-      - name: Build and run tests
-        env:
-          CCACHE_BASEDIR: ${{ github.workspace }}
-          CCACHE_DIR: ${{ github.workspace }}/.ccache
-          CCACHE_COMPRESS: true
-          CCACHE_COMPRESSLEVEL: 6
-          CCACHE_MAXSIZE: 500M
+      - name: Generate coverage baseline
+        if: matrix.build == 'coverage'
+        run: |
+          lcov --directory ./build/ --zerocounters
+          lcov --directory ./build/ --capture --initial --output-file ./build/coverage_report.baseline
+
+      - name: Run tests
         run: |
           cd build
           ctest . -j2 --output-on-failure
 
-      - name: Run lcov
+      - name: Generate coverage report
         if: matrix.build == 'coverage'
         run: |
-          lcov --directory ./build/ --capture --output-file ./build/coverage_report --gcov-tool gcov-10
-          lcov --remove ./build/coverage_report '/usr/*' '${{ github.workspace }}/src/lib/*' '${{ github.workspace }}/build/vendor/*' --output-file ./build/coverage_report
-          lcov --list ./build/coverage_report
+          lcov --directory ./build/ --capture --output-file ./build/coverage_report.captured
+          lcov -a ./build/coverage_report.baseline -a ./build/coverage_report.captured --output-file ./build/coverage_report.total
+          lcov --remove ./build/coverage_report.total '/usr/*' '${{ github.workspace }}/src/lib/*' '${{ github.workspace }}/src/test/*' '${{ github.workspace }}/build/vendor/*' --output-file ./build/coverage_report
 
       - name: Submit coverage report
         if: matrix.build == 'coverage'

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -43,6 +43,9 @@ jobs:
           fetch-depth: 2
           submodules: recursive
 
+      - name: Add package source
+        run: bash ./src/lib/seqan3/.github/workflows/scripts/configure_apt.sh
+
       - name: Install CMake
         env:
           BUILD: ${{ matrix.build }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project (iGenVar VERSION 1.0.0)
 # Make Release default build type
 if (NOT CMAKE_BUILD_TYPE)
     set (CMAKE_BUILD_TYPE Release CACHE STRING
-         "Choose the type of build, options are: Debug Release RelWithDebInfo"
+         "Choose the type of build, options are: Debug Release Coverage RelWithDebInfo MinSizeRel."
          FORCE)
 endif ()
 
@@ -27,6 +27,7 @@ set (FontReset "${Esc}[m")
 # Dependency: SeqAn3.
 find_package (SeqAn3 QUIET REQUIRED HINTS lib/seqan3/build_system)
 
+# Use ccache.
 include ("${SEQAN3_CLONE_DIR}/test/cmake/seqan3_require_ccache.cmake")
 seqan3_require_ccache ()
 
@@ -41,25 +42,7 @@ FetchContent_Populate(hclust)
 add_library ("fastcluster" STATIC ${hclust_SOURCE_DIR}/fastcluster.cpp)
 target_include_directories ("fastcluster" PUBLIC ${hclust_SOURCE_DIR})
 
-# Code Coverage Configuration
-add_library (igenvar_coverage_config INTERFACE)
-
-option (IGENVAR_CODE_COVERAGE "Enable coverage reporting" OFF)
-if (IGENVAR_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  # Add required flags (GCC & LLVM/Clang)
-  target_compile_options (igenvar_coverage_config INTERFACE
-    --coverage # sets all required flags
-  )
-  if (CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE MATCHES "Debug")
-    message (WARNING "Please build code coverage in Debug, i.e., cmake -DCMAKE_BUILD_TYPE=Debug")
-  endif ()
-  if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-    target_link_options (igenvar_coverage_config INTERFACE --coverage)
-  else ()
-    target_link_libraries (igenvar_coverage_config INTERFACE --coverage)
-  endif ()
-endif ()
-
+# Add the application.
 add_subdirectory (src)
 message (STATUS "${FontBold}You can run `make` to build the application.${FontReset}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,3 @@ target_include_directories ("${PROJECT_NAME}_lib" PUBLIC ../include)
 
 add_executable ("${PROJECT_NAME}" iGenVar.cpp)
 target_link_libraries ("${PROJECT_NAME}" PRIVATE "${PROJECT_NAME}_lib")
-
-# Include code-coverage settings:
-target_link_libraries ("${PROJECT_NAME}" PUBLIC igenvar_coverage_config)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,5 +85,6 @@ endmacro ()
 include (data/datasources.cmake)
 add_subdirectory (api)
 add_subdirectory (cli)
+add_subdirectory (coverage)
 
 message (STATUS "${FontBold}You can run `make test` to build and run tests.${FontReset}")

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -301,7 +301,7 @@ TEST_F(iGenVar_cli_test, test_unknown_argument)
     std::string expected_err
     {
         "[Error] You have chosen an invalid input value: 9. "
-        "Please use one of: [read_depth,3,read_pairs,2,split_read,1,cigar_string,0]\n"
+        "Please use one of: [0,cigar_string,1,split_read,2,read_pairs,3,read_depth]\n"
     };
     EXPECT_EQ(result.exit_code, 65280);
     EXPECT_EQ(result.out, std::string{});

--- a/test/coverage/CMakeLists.txt
+++ b/test/coverage/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required (VERSION 3.8)
+
+# Add a custom build type: Coverage
+
+set (CMAKE_CXX_FLAGS_COVERAGE
+     "${CMAKE_CXX_FLAGS_DEBUG} --coverage -fprofile-arcs -ftest-coverage" CACHE STRING
+     "Flags used by the C++ compiler during coverage builds."
+     FORCE)
+set (CMAKE_C_FLAGS_COVERAGE
+     "${CMAKE_C_FLAGS_DEBUG} --coverage -fprofile-arcs -ftest-coverage" CACHE STRING
+     "Flags used by the C compiler during coverage builds."
+     FORCE)
+set (CMAKE_EXE_LINKER_FLAGS_COVERAGE
+     "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -Wl,-lgcov" CACHE STRING
+     "Flags used for linking binaries during coverage builds."
+     FORCE)
+set (CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+     "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -Wl,-lgcov" CACHE STRING
+     "Flags used by the shared libraries linker during coverage builds."
+     FORCE)
+
+mark_as_advanced (
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE)

--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -3,4 +3,7 @@
 This is the test for the code coverage.
 It reaches 100% if each code line is executed at least once through the app tests.
 
-The coverage tests are not yet implemented.
+Coverage tests are not yet part of the CMake configuration like it is in SeqAn3.
+However, the CI tests code coverage by running gcov and uploading the results to codecov.
+
+The custom build type `Coverage` can be used to configure the project such that coverage reports are possible.


### PR DESCRIPTION
A merge of https://github.com/seqan/app-template/pull/47

---
Old:
We also need to link the coverage config against the lib and the tests.

Also, I followed https://wiki.documentfoundation.org/Development/Lcov and try really hard not to run the tests before I got some baseline coverage, which is the same we do in seqan3.