### PR TITLE
[FEATURE, FIX] add contig to the vcf header 

### DIFF
--- a/include/variant_detection/variant_detection.hpp
+++ b/include/variant_detection/variant_detection.hpp
@@ -1,20 +1,32 @@
 #pragma once
 
 #include <seqan3/std/filesystem>    // for filesystem
+#include <map>
 #include <vector>
 
 #include "iGenVar.hpp"              // for struct cmd_arguments
 #include "structures/junction.hpp"  // for class Junction
 
+/*! \brief Reads the header of the input file. Checks if input file is sorted and reads the reference sequence
+ *         dictionary. Stores the reference sequence lengths in parameter `reference_lengths` and returns the list of
+ *         reference sequences.
+ *
+ * \param[in, out]  alignment_file - short or long reads input file
+ * \param[in, out]  references_lengths - reference sequence dictionary parsed from \@SQ header lines
+ */
+std::deque<std::string> read_header_information(auto & alignment_file,
+                                                std::map<std::string, int32_t> & references_lengths);
+
 /*! \brief Detects junctions between distant genomic positions by analyzing a short read alignment file (sam/bam). The
  *         detected junctions are stored in a vector.
  *
  * \param[in, out]  junctions - a vector of junctions
+ * \param[in, out]  references_lengths - reference sequence dictionary parsed from \@SQ header lines
  * \param[in]       args - command line arguments:\n
  *                         **args.alignment_short_reads_file_path** - short reads input file, path to the sam/bam file\n
  *                         **args.methods** - list of methods for detecting junctions
  *                            (0: cigar_string, 1: split_read, 2: read_pairs, 3: read_depth) - *default: all methods*\n
- * 
+ *
  *
  * \details Detects junctions from the CIGAR strings and supplementary alignment tags of read alignment records.
  *          We filter unmapped alignments, secondary alignments, duplicates and alignments with low mapping quality.
@@ -22,18 +34,22 @@
  *          For primary alignments, also the split read information is analyzed.
  */
 void detect_junctions_in_short_reads_sam_file(std::vector<Junction> & junctions,
+                                              std::map<std::string, int32_t> & references_lengths,
                                               cmd_arguments const & args);
 
 /*! \brief Detects junctions between distant genomic positions by analyzing a long read alignment file (sam/bam). The
  *         detected junctions are stored in a vector.
  *
  * \param[in, out]  junctions - a vector of junctions
+ * \param[in, out]  references_lengths - reference sequence dictionary parsed from \@SQ header lines
  * \param[in]       args - command line arguments:\n
  *                         **args.alignment_long_reads_file_path** - long reads input file, path to the sam/bam file\n
  *                         **args.methods** - list of methods for detecting junctions
  *                            (0: cigar_string, 1: split_read, 2: read_pairs, 3: read_depth) - *default: all methods*\n
- *                         **args.min_var_length** - minimum length of variants to detect (expected to be non-negative) - *default: 30 bp*\n
- *                         **args.max_overlap** - maximum overlap between alignment segments (expected to be non-negative) - *default: 10 bp*
+ *                         **args.min_var_length** - minimum length of variants to detect
+ *                            (expected to be non-negative) - *default: 30 bp*\n
+ *                         **args.max_overlap** - maximum overlap between alignment segments
+ *                            (expected to be non-negative) - *default: 10 bp*
  *
  *
  * \details Detects junctions from the CIGAR strings and supplementary alignment tags of read alignment records.
@@ -42,4 +58,5 @@ void detect_junctions_in_short_reads_sam_file(std::vector<Junction> & junctions,
  *          For primary alignments, also the split read information is analyzed.
  */
 void detect_junctions_in_long_reads_sam_file(std::vector<Junction> & junctions,
+                                             std::map<std::string, int32_t> & references_lengths,
                                              cmd_arguments const & args);

--- a/include/variant_detection/variant_output.hpp
+++ b/include/variant_detection/variant_output.hpp
@@ -10,34 +10,46 @@
 
 /*! \brief Detects genomic variants from junction clusters and prints them to output stream in VCF format.
  *
- * \param[in]       clusters    - input junction clusters
- * \param[in]       args        - command line arguments:\n
- *                                **args.min_var_length** - minimum length of variants to detect (expected to be non-negative) - *default: 30 bp* \n
- *                                **args.max_var_length** - maximum length of variants to detect (expected to be non-negative) - *default: 1,000,000 bp*\n
- *                                **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types (expected to be non-negative) - *default: 5 bp*
- * \param[in, out]  out_stream  - output stream
+ * \param[in]       references_lengths  - reference sequence dictionary parsed from \@SQ header lines
+ * \param[in]       clusters            - input junction clusters
+ * \param[in]       args                - command line arguments:\n
+ *                                        **args.min_var_length** - minimum length of variants to detect
+ *                                           (expected to be non-negative) - *default: 30 bp* \n
+ *                                        **args.max_var_length** - maximum length of variants to detect
+ *                                           (expected to be non-negative) - *default: 1,000,000 bp*\n
+ *                                        **args.max_tol_inserted_length** - longest tolerated inserted sequence at
+ *                                           non-INS SV types (expected to be non-negative) - *default: 5 bp*
+ * \param[in, out]  out_stream          - output stream
  *
  * \details Extracts genomic variants from given junction clusters.
- *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the SV).
+ *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the
+ *          SV).
  */
-void find_and_output_variants(std::vector<Cluster> const & clusters,
+void find_and_output_variants(std::map<std::string, int32_t> & references_lengths,
+                              std::vector<Cluster> const & clusters,
                               cmd_arguments const & args,
                               std::ostream & out_stream);
 
 
 /*! \brief Detects genomic variants from junction clusters and prints them in output file in VCF format.
  *
- * \param[in] clusters          - input junction clusters
- * \param[in] args              - command line arguments:\n
- *                                **args.min_var_length** - minimum length of variants to detect (expected to be non-negative) - *default: 30 bp*\n
- *                                **args.max_var_length** - maximum length of variants to detect (expected to be non-negative) - *default: 1,000,000 bp*\n
- *                                **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types (expected to be non-negative) - *default: 5 bp*
- * \param[in] output_file_path  - output file path
+ * \param[in]       references_lengths  - reference sequence dictionary parsed from \@SQ header lines
+ * \param[in]       clusters            - input junction clusters
+ * \param[in]       args                - command line arguments:\n
+ *                                        **args.min_var_length** - minimum length of variants to detect
+ *                                           (expected to be non-negative) - *default: 30 bp*\n
+ *                                        **args.max_var_length** - maximum length of variants to detect
+ *                                           (expected to be non-negative) - *default: 1,000,000 bp*\n
+ *                                        **args.max_tol_inserted_length** - longest tolerated inserted sequence at
+ *                                           non-INS SV types (expected to be non-negative) - *default: 5 bp*
+ * \param[in]       output_file_path    - output file path
  *
  * \details Extracts genomic variants from given junction clusters.
- *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the SV).
+ *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the
+ *          SV).
  */
 //!\overload
-void find_and_output_variants(std::vector<Cluster> const & clusters,
+void find_and_output_variants(std::map<std::string, int32_t> & references_lengths,
+                              std::vector<Cluster> const & clusters,
                               cmd_arguments const & args,
                               std::filesystem::path const & output_file_path);

--- a/include/variant_parser/variant_record.hpp
+++ b/include/variant_parser/variant_record.hpp
@@ -66,16 +66,21 @@ public:
      *
      * \tparam stream_type - a stream to print the output to
      *
-     * \param[in, out] out_stream - the output stream to print to
+     * \param[in]       references_lengths - references sequence dictionary parsed from \@SQ header lines
+     * \param[in, out]  out_stream - the output stream to print to
      */
     template<typename stream_type>
     //!cond
         requires seqan3::output_stream<stream_type>
     //!endcond
-    void print(stream_type & out_stream)
+    void print(std::map<std::string, int32_t> & references_lengths, stream_type & out_stream)
     {
         out_stream << "##fileformat=" << fileformat << '\n';
         out_stream << "##source=" << source << '\n';
+
+        for(auto const& [id, length] : references_lengths)
+            out_stream << "##contig=<ID=" << id << ",length=" << length << ">\n";
+
         for (auto const & i : info)
         {
             out_stream << "##INFO=<ID=" << i.key << ",Number=" << std::to_string(i.number) << ",Type=" << i.type

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -1,5 +1,7 @@
 #include "iGenVar.hpp"
 
+#include <map>
+
 #include <seqan3/core/debug_stream.hpp>                     // for seqan3::debug_stream
 
 #include "modules/clustering/hierarchical_clustering_method.hpp"    // for the hierarchical clustering method
@@ -78,21 +80,20 @@ void detect_variants_in_alignment_file(cmd_arguments const & args)
 {
     // Store junctions
     std::vector<Junction> junctions{};
+    std::map<std::string, int32_t> references_lengths{};
 
     // short reads
     if (args.alignment_short_reads_file_path != "")
     {
         seqan3::debug_stream << "Detect junctions in short reads...\n";
-        detect_junctions_in_short_reads_sam_file(junctions,
-                                                 args);
+        detect_junctions_in_short_reads_sam_file(junctions, references_lengths, args);
     }
 
     // long reads
     if (args.alignment_long_reads_file_path != "")
     {
         seqan3::debug_stream << "Detect junctions in long reads...\n";
-        detect_junctions_in_long_reads_sam_file(junctions,
-                                                args);
+        detect_junctions_in_long_reads_sam_file(junctions, references_lengths, args);
     }
 
     std::sort(junctions.begin(), junctions.end());
@@ -131,7 +132,7 @@ void detect_variants_in_alignment_file(cmd_arguments const & args)
             break;
     }
 
-    find_and_output_variants(clusters, args, args.output_file_path);
+    find_and_output_variants(references_lengths, clusters, args, args.output_file_path);
 }
 
 int main(int argc, char ** argv)

--- a/src/variant_detection/variant_output.cpp
+++ b/src/variant_detection/variant_output.cpp
@@ -5,7 +5,8 @@
 #include "structures/junction.hpp"              // for class Junction
 #include "variant_parser/variant_record.hpp"    // for class variant_header
 
-void find_and_output_variants(std::vector<Cluster> const & clusters,
+void find_and_output_variants(std::map<std::string, int32_t> & references_lengths,
+                              std::vector<Cluster> const & clusters,
                               cmd_arguments const & args,
                               std::ostream & out_stream)
 {
@@ -14,7 +15,7 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
     header.add_meta_info("SVTYPE", 1, "String", "Type of SV called.", "iGenVarCaller", "1.0");
     header.add_meta_info("SVLEN", 1, "Integer", "Length of SV called.", "iGenVarCaller", "1.0");
     header.add_meta_info("END", 1, "Integer", "End position of SV called.", "iGenVarCaller", "1.0");
-    header.print(out_stream);
+    header.print(references_lengths, out_stream);
     for (size_t i = 0; i < clusters.size(); ++i)
     {
         Breakend mate1 = clusters[i].get_average_mate1();
@@ -71,13 +72,14 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
 }
 
 //!\overload
-void find_and_output_variants(std::vector<Cluster> const & clusters,
+void find_and_output_variants(std::map<std::string, int32_t> & references_lengths,
+                              std::vector<Cluster> const & clusters,
                               cmd_arguments const & args,
                               std::filesystem::path const & output_file_path)
 {
     if (output_file_path.empty())
     {
-        find_and_output_variants(clusters, args, std::cout);
+        find_and_output_variants(references_lengths, clusters, args, std::cout);
     }
     else
     {
@@ -86,7 +88,7 @@ void find_and_output_variants(std::vector<Cluster> const & clusters,
         {
             throw std::runtime_error{"Could not open file '" + output_file_path.string() + "' for reading."};
         }
-        find_and_output_variants(clusters, args, out_file);
+        find_and_output_variants(references_lengths, clusters, args, out_file);
         out_file.close();
     }
 }

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -107,6 +107,7 @@ std::string expected_res_default
 {
     "##fileformat=VCFv4.3\n"
     "##source=iGenVarCaller\n"
+    "##contig=<ID=chr21,length=46709983>\n"
     "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
@@ -118,6 +119,7 @@ std::string expected_res_empty
 {
     "##fileformat=VCFv4.3\n"
     "##source=iGenVarCaller\n"
+    "##contig=<ID=chr1,length=368>\n"
     "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"Length of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"
     "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of SV called.\",Source=\"iGenVarCaller\",Version=\"1.0\">\n"

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -49,7 +49,7 @@ std::string const help_page_part_2
     "VERSION\n"
     "    Last update: 30-03-2021\n"
     "    iGenVar version: 0.0.3\n"
-    "    SeqAn version: 3.0.3\n"
+    "    SeqAn version: 3.1.0-rc.1\n"
     "\n"
     "URL\n"
     "    https://github.com/seqan/iGenVar/\n"

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -29,4 +29,4 @@ declare_datasource (FILE output_err.txt
 # copies file to <build>/data/output_res.txt
 declare_datasource (FILE output_res.txt
                     URL ${CMAKE_SOURCE_DIR}/test/data/mini_example/output_res.txt
-                    URL_HASH SHA256=cdd239ba1d5447f5f5ec9aa844afb3634d84b1f61396f20fe5ee26a58a644de4)
+                    URL_HASH SHA256=5c4250e3323b89db54029ce0d069c097a2a28195b5b7b0e08deee7cdfb720d85)

--- a/test/data/mini_example/output_res.txt
+++ b/test/data/mini_example/output_res.txt
@@ -1,5 +1,6 @@
 ##fileformat=VCFv4.3
 ##source=iGenVarCaller
+##contig=<ID=chr1,length=368>
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of SV called.",Source="iGenVarCaller",Version="1.0">
 ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of SV called.",Source="iGenVarCaller",Version="1.0">
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of SV called.",Source="iGenVarCaller",Version="1.0">


### PR DESCRIPTION
Resolves part of #127 (contig to the vcf header)

We also update seqan3 here to get the fix for SAM/BAM header bugs: https://github.com/seqan/seqan3/issues/2600