### PR TITLE
[FEATURE] add  intermediate result output

### DIFF
--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -10,6 +10,8 @@ struct cmd_arguments
     std::filesystem::path alignment_long_reads_file_path{""};
     std::filesystem::path output_file_path{};
     std::string vcf_sample_name{"GENOTYPE"};
+    std::filesystem::path junctions_file_path{};
+    std::filesystem::path clusters_file_path{};
     std::vector<detection_methods> methods{cigar_string, split_read, read_pairs, read_depth};   // default: all methods
     clustering_methods clustering_method{hierarchical_clustering};                              // default: hierarchical clustering method
     refinement_methods refinement_method{no_refinement};                                        // default: no refinement

--- a/test/api/detection_test.cpp
+++ b/test/api/detection_test.cpp
@@ -387,6 +387,8 @@ TEST(junction_detection, analyze_sa_tag)
                        std::filesystem::path{},
                        std::filesystem::path{},
                        "GENOTYPE",
+                       std::filesystem::path{},
+                       std::filesystem::path{},
                        std::vector<detection_methods>{cigar_string, split_read, read_pairs, read_depth},
                        simple_clustering,
                        sVirl_refinement_method,

--- a/test/api/input_file_test.cpp
+++ b/test/api/input_file_test.cpp
@@ -11,6 +11,8 @@ using seqan3::operator""_dna5;
 std::string const default_alignment_short_reads_file_path = DATADIR"paired_end_mini_example.sam";
 std::string const default_alignment_long_reads_file_path = DATADIR"simulated.minimap2.hg19.coordsorted_cutoff.sam";
 std::filesystem::path const empty_output_path{};
+std::filesystem::path const empty_junctions_path{};
+std::filesystem::path const empty_clusters_path{};
 std::vector<detection_methods> const default_methods{cigar_string, split_read, read_pairs, read_depth};
 constexpr int32_t default_min_length = 30;
 constexpr int32_t default_max_overlap = 10;
@@ -52,6 +54,8 @@ TEST(input_file, detect_junctions_in_short_read_sam_file)
                        "",
                        empty_output_path,
                        "GENOTYPE",
+                       empty_junctions_path,
+                       empty_clusters_path,
                        default_methods,
                        simple_clustering,
                        sVirl_refinement_method,
@@ -85,6 +89,8 @@ TEST(input_file, detect_junctions_in_long_reads_sam_file)
                        default_alignment_long_reads_file_path,
                        empty_output_path,
                        "GENOTYPE",
+                       empty_junctions_path,
+                       empty_clusters_path,
                        default_methods,
                        simple_clustering,
                        sVirl_refinement_method,
@@ -189,6 +195,8 @@ TEST(input_file, long_read_sam_file_unsorted)
                        unsorted_sam_path,
                        empty_output_path,
                        "GENOTYPE",
+                       empty_junctions_path,
+                       empty_clusters_path,
                        default_methods,
                        simple_clustering,
                        no_refinement,
@@ -259,6 +267,8 @@ TEST(input_file, short_and_long_read_sam_file_with_different_references_lengths)
                        long_sam_path,
                        empty_output_path,
                        "GENOTYPE",
+                       empty_junctions_path,
+                       empty_clusters_path,
                        default_methods,
                        simple_clustering,
                        no_refinement,

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -8,6 +8,8 @@
 
 std::string const default_alignment_long_reads_file_path = "simulated.minimap2.hg19.coordsorted_cutoff.sam";
 std::string const vcf_out_file_path = "variants_file_out.vcf";
+std::string const junctions_out_file_path = "junctions_file_out.txt";
+std::string const clusters_out_file_path = "clusters_file_out.txt";
 
 std::string const help_page_part_1
 {
@@ -70,6 +72,14 @@ std::string const help_page_part_2
 
 std::string const help_page_advanced
 {
+    "    -a, --junctions (std::filesystem::path)\n"
+    "          The path of the optional junction output file. If no path is given,\n"
+    "          junctions will not be output. Default: \"\". Write permissions must be\n"
+    "          granted.\n"
+    "    -b, --clusters (std::filesystem::path)\n"
+    "          The path of the optional cluster output file. If no path is given,\n"
+    "          clusters will not be output. Default: \"\". Write permissions must be\n"
+    "          granted.\n"
     "    -m, --method (List of detection_methods)\n"
     "          Choose the detection method(s) to be used. Default:\n"
     "          [cigar_string,split_read,read_pairs,read_depth]. Value must be one\n"
@@ -362,6 +372,31 @@ TEST_F(iGenVar_cli_test, test_outfile)
     //this does not specifically check if file exists, rather if its readable.
     EXPECT_TRUE(f.is_open());
     EXPECT_EQ(buffer.str(), expected_res_default);
+}
+
+TEST_F(iGenVar_cli_test, test_intermediate_result_output)
+{
+    cli_test_result result = execute_app("iGenVar",
+                                         "-j ", data(default_alignment_long_reads_file_path),
+                                         "-a ", junctions_out_file_path,
+                                         "-b ", clusters_out_file_path);
+    std::ifstream f1;
+    f1.open(junctions_out_file_path);
+    std::stringstream buffer1;
+    buffer1 << f1.rdbuf();
+
+    // This does not specifically check if file exists, rather if its readable.
+    EXPECT_TRUE(f1.is_open());
+    EXPECT_NE(buffer1.str(), "");
+
+    std::ifstream f2;
+    f2.open(clusters_out_file_path);
+    std::stringstream buffer2;
+    buffer2 << f2.rdbuf();
+
+    // This does not specifically check if file exists, rather if its readable.
+    EXPECT_TRUE(f2.is_open());
+    EXPECT_NE(buffer2.str(), "");
 }
 
 TEST_F(iGenVar_cli_test, with_detection_method_arguments)


### PR DESCRIPTION
For investigating specific variants, improving our heuristics and parameters and debugging it would be very helpful to view the junctions and clusters generated by iGenVar. However, we currently only output the final variants in VCF.

This PR adds two CLI parameters that the user can set to define file paths where junctions and clusters are output to.