### PR TITLE
[FEATURE] set number of decompression threads

### DIFF
--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -16,6 +16,7 @@ struct cmd_arguments
     int32_t max_var_length = 1000000;
     int32_t max_tol_inserted_length = 5;
     int32_t max_overlap = 10;
+    int16_t threads = 1;
 };
 
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args);

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -41,6 +41,9 @@ std::string const help_page_part_1
     "          The path of the vcf output file. If no path is given, will output to\n"
     "          standard output. Default: \"\". Write permissions must be granted.\n"
     "          Valid file extensions are: [vcf].\n"
+    "    -t, --threads (signed 16 bit integer)\n"
+    "          Specify the number of decompression threads used for reading BAM\n"
+    "          files. Default: 1.\n"
 };
 
 std::string const help_page_part_2
@@ -87,7 +90,7 @@ std::string const help_page_advanced
     "          detected. SVs larger than this threshold can still be output as\n"
     "          translocations. This value needs to be non-negative. Default:\n"
     "          1000000.\n"
-    "    -t, --max_tol_inserted_length (signed 32 bit integer)\n"
+    "    -q, --max_tol_inserted_length (signed 32 bit integer)\n"
     "          Specify what should be the longest tolerated inserted sequence at\n"
     "          sites of non-INS SVs. This value needs to be non-negative. Default:\n"
     "          5.\n"
@@ -259,7 +262,7 @@ TEST_F(iGenVar_cli_test, fail_negative_max_tol_inserted_length)
 {
     cli_test_result result = execute_app("iGenVar",
                                          "-j", data(default_alignment_long_reads_file_path),
-                                         "-t -30");
+                                         "-q -30");
     std::string expected_err
     {
         "[Error] You gave a negative max_tol_inserted_length parameter.\n"


### PR DESCRIPTION
This PR fixes #129.

Changes:
- add CLI parameter --threads (default 1)
- use its value to set number of decompression threads
- rename -t (max_tol_inserted_length) to -q to associate --threads with -t