### PR TITLE
[FEATURE] Add quality and cutoff parameters

### DIFF
--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -19,6 +19,7 @@ struct cmd_arguments
     int32_t max_overlap = 10;
     int16_t threads = 1;
     int32_t min_qual = 1;
+    double hierarchical_clustering_cutoff = 10;
 };
 
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args);
@@ -52,6 +53,8 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
  *                                          (expected to be non-negative) - *default: 10 bp*\n
  *                   **args.min_qual** - minimum quality (amount of supporting reads) of a structural variant
  *                                       (expected to be non-negative) - *default: 1 supporting read*\n
+ *                   **args.hierarchical_clustering_cutoff** - distance cutoff for the hierarchical clustering
+ *                                                             (expected to be non-negative) - *default: 10*
  *
  *
  * \details Detects novel junctions from read alignment records using different detection methods.

--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -18,6 +18,7 @@ struct cmd_arguments
     int32_t max_tol_inserted_length = 5;
     int32_t max_overlap = 10;
     int16_t threads = 1;
+    int32_t min_qual = 1;
 };
 
 void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args);
@@ -41,10 +42,16 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
  *                      (0: no_refinement,
  *                       1: sViper_refinement_method,
  *                       2: sVirl_refinement_method) - *default: no refinement*\n
- *                   **args.min_var_length** - minimum length of variants to detect (expected to be non-negative) - *default: 30 bp*\n
- *                   **args.max_var_length** - maximum length of variants to detect (expected to be non-negative) - *default: 1,000,000 bp*\n
- *                   **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types (expected to be non-negative) - *default: 5 bp*\n
- *                   **args.max_overlap** - maximum overlap between alignment segments (expected to be non-negative) - *default: 10 bp*
+ *                   **args.min_var_length** - minimum length of variants to detect
+ *                                             (expected to be non-negative) - *default: 30 bp*\n
+ *                   **args.max_var_length** - maximum length of variants to detect
+ *                                             (expected to be non-negative) - *default: 1,000,000 bp*\n
+ *                   **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV types
+ *                                                      (expected to be non-negative) - *default: 5 bp*\n
+ *                   **args.max_overlap** - maximum overlap between alignment segments
+ *                                          (expected to be non-negative) - *default: 10 bp*\n
+ *                   **args.min_qual** - minimum quality (amount of supporting reads) of a structural variant
+ *                                       (expected to be non-negative) - *default: 1 supporting read*\n
  *
  *
  * \details Detects novel junctions from read alignment records using different detection methods.

--- a/include/modules/clustering/hierarchical_clustering_method.hpp
+++ b/include/modules/clustering/hierarchical_clustering_method.hpp
@@ -26,7 +26,7 @@ std::vector<std::vector<Junction>> split_partition_based_on_mate2(std::vector<Ju
 /*! \brief Compute the distance between two junctions.
  *         For two junctions that connect the same reference sequences and have the same
  *         orientations, the distance is the sum of a) the distance between the first mates,
- *         b) the distance between the second mates, and c) the absolute size difference 
+ *         b) the distance between the second mates, and c) the absolute size difference
  *         of the inserted sequences. For other junctions, the distance takes the maximal value.
  *
  * \param[in] lhs - left side junction
@@ -39,6 +39,9 @@ int junction_distance(Junction const & lhs, Junction const & rhs);
  *
  * \param[in] junctions - a vector of junctions (needs to be sorted)
  * \param[in] clustering_cutoff - distance cutoff for clustering
+ *
+ * \details For the algorithms we use the library hclust.
+ * \see https://lionel.kr.hs-niederrhein.de/~dalitz/data/hclust/ (last access 01.06.2021).
  */
 std::vector<Cluster> hierarchical_clustering_method(std::vector<Junction> const & junctions,
                                                     double clustering_cutoff);

--- a/include/variant_detection/variant_output.hpp
+++ b/include/variant_detection/variant_output.hpp
@@ -10,20 +10,24 @@
 
 /*! \brief Detects genomic variants from junction clusters and prints them to output stream in VCF format.
  *
- * \param[in]       references_lengths  - reference sequence dictionary parsed from \@SQ header lines
- * \param[in]       clusters            - input junction clusters
- * \param[in]       args                - command line arguments:\n
- *                                        **args.min_var_length** - minimum length of variants to detect
- *                                           (expected to be non-negative) - *default: 30 bp* \n
- *                                        **args.max_var_length** - maximum length of variants to detect
- *                                           (expected to be non-negative) - *default: 1,000,000 bp*\n
- *                                        **args.max_tol_inserted_length** - longest tolerated inserted sequence at
- *                                           non-INS SV types (expected to be non-negative) - *default: 5 bp*
- * \param[in, out]  out_stream          - output stream
+ * \param[in] references_lengths - reference sequence dictionary parsed from \@SQ header lines
+ * \param[in] clusters           - input junction clusters
+ * \param[in] args               - command line arguments:\n
+ *                                 **args.min_var_length** - minimum length of variants to detect
+ *                                                           (expected to be non-negative) - *default: 30 bp* \n
+ *                                 **args.max_var_length** - maximum length of variants to detect
+ *                                                           (expected to be non-negative) - *default: 1,000,000 bp*\n
+ *                                 **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV
+ *                                                                    types (expected to be non-negative)
+ *                                                                  - *default: 5 bp*\n
+ *                                 **args.min_qual** - minimum quality (amount of supporting reads) of a structural
+ *                                                     variant (expected to be non-negative)
+ *                                                   - *default: 1 supporting read*\n
+ * \param[in, out] out_stream    - output stream
  *
  * \details Extracts genomic variants from given junction clusters.
- *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the
- *          SV).
+ *          The quality of an SV is estimated based on the size of the cluster
+ *          (i.e. the number of reads supporting the SV).
  */
 void find_and_output_variants(std::map<std::string, int32_t> & references_lengths,
                               std::vector<Cluster> const & clusters,
@@ -33,20 +37,24 @@ void find_and_output_variants(std::map<std::string, int32_t> & references_length
 
 /*! \brief Detects genomic variants from junction clusters and prints them in output file in VCF format.
  *
- * \param[in]       references_lengths  - reference sequence dictionary parsed from \@SQ header lines
- * \param[in]       clusters            - input junction clusters
- * \param[in]       args                - command line arguments:\n
- *                                        **args.min_var_length** - minimum length of variants to detect
- *                                           (expected to be non-negative) - *default: 30 bp*\n
- *                                        **args.max_var_length** - maximum length of variants to detect
- *                                           (expected to be non-negative) - *default: 1,000,000 bp*\n
- *                                        **args.max_tol_inserted_length** - longest tolerated inserted sequence at
- *                                           non-INS SV types (expected to be non-negative) - *default: 5 bp*
- * \param[in]       output_file_path    - output file path
+ * \param[in] references_lengths - reference sequence dictionary parsed from \@SQ header lines
+ * \param[in] clusters           - input junction clusters
+ * \param[in] args               - command line arguments:\n
+ *                                 **args.min_var_length** - minimum length of variants to detect
+ *                                                           (expected to be non-negative) - *default: 30 bp* \n
+ *                                 **args.max_var_length** - maximum length of variants to detect
+ *                                                           (expected to be non-negative) - *default: 1,000,000 bp*\n
+ *                                 **args.max_tol_inserted_length** - longest tolerated inserted sequence at non-INS SV
+ *                                                                    types (expected to be non-negative)
+ *                                                                  - *default: 5 bp*\n
+ *                                 **args.min_qual** - minimum quality (amount of supporting reads) of a structural
+ *                                                     variant (expected to be non-negative)
+ *                                                   - *default: 1 supporting read*\n
+ ** \param[in] output_file_path  - output file path
  *
  * \details Extracts genomic variants from given junction clusters.
- *          The quality of an SV is estimated based on the size of the cluster (i.e. the number of reads supporting the
- *          SV).
+ *          The quality of an SV is estimated based on the size of the cluster
+ *          (i.e. the number of reads supporting the SV).
  */
 //!\overload
 void find_and_output_variants(std::map<std::string, int32_t> & references_lengths,

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -85,6 +85,10 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       "Specify the maximum allowed overlap between two alignment segments. "
                       "This value needs to be non-negative.",
                       seqan3::option_spec::advanced);
+    parser.add_option(args.min_qual, 'u', "min_qual",
+                      "Specify the minimum quality (amount of supporting reads) of a structural variant to be reported "
+                      "in the vcf output file. This value needs to be non-negative.",
+                      seqan3::option_spec::advanced);
 }
 
 void detect_variants_in_alignment_file(cmd_arguments const & args)
@@ -204,6 +208,11 @@ int main(int argc, char ** argv)
     if (args.max_overlap < 0)
     {
         seqan3::debug_stream << "[Error] You gave a negative max_overlap parameter.\n";
+        return -1;
+    }
+    if (args.min_qual < 0)
+    {
+        seqan3::debug_stream << "[Error] You gave a negative min_qual parameter.\n";
         return -1;
     }
 

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -89,6 +89,12 @@ void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments 
                       "Specify the minimum quality (amount of supporting reads) of a structural variant to be reported "
                       "in the vcf output file. This value needs to be non-negative.",
                       seqan3::option_spec::advanced);
+
+    // Options - Clustering specifications:
+    parser.add_option(args.hierarchical_clustering_cutoff, 'z', "hierarchical_clustering_cutoff",
+                      "Specify the distance cutoff for the hierarchical clustering. "
+                      "This value needs to be non-negative.",
+                      seqan3::option_spec::advanced);
 }
 
 void detect_variants_in_alignment_file(cmd_arguments const & args)
@@ -124,7 +130,7 @@ void detect_variants_in_alignment_file(cmd_arguments const & args)
             clusters = simple_clustering_method(junctions);
             break;
         case 1: // hierarchical clustering
-            clusters = hierarchical_clustering_method(junctions, 10.0);
+            clusters = hierarchical_clustering_method(junctions, args.hierarchical_clustering_cutoff);
             break;
         case 2: // self-balancing_binary_tree,
             seqan3::debug_stream << "The self-balancing binary tree clustering method is not yet implemented\n";
@@ -213,6 +219,11 @@ int main(int argc, char ** argv)
     if (args.min_qual < 0)
     {
         seqan3::debug_stream << "[Error] You gave a negative min_qual parameter.\n";
+        return -1;
+    }
+    if (args.hierarchical_clustering_cutoff < 0)
+    {
+        seqan3::debug_stream << "[Error] You gave a negative hierarchical_clustering_cutoff parameter.\n";
         return -1;
     }
 

--- a/src/variant_detection/variant_output.cpp
+++ b/src/variant_detection/variant_output.cpp
@@ -18,52 +18,55 @@ void find_and_output_variants(std::map<std::string, int32_t> & references_length
     header.print(references_lengths, args.vcf_sample_name, out_stream);
     for (size_t i = 0; i < clusters.size(); ++i)
     {
-        Breakend mate1 = clusters[i].get_average_mate1();
-        Breakend mate2 = clusters[i].get_average_mate2();
         size_t cluster_size = clusters[i].get_cluster_size();
-        if (mate1.orientation == mate2.orientation)
+        if (cluster_size >= args.min_qual)
         {
-            if (mate1.seq_name == mate2.seq_name)
+            Breakend mate1 = clusters[i].get_average_mate1();
+            Breakend mate2 = clusters[i].get_average_mate2();
+            if (mate1.orientation == mate2.orientation)
             {
-                int32_t mate1_pos = mate1.position;
-                int32_t mate2_pos = mate2.position;
-                int32_t insert_size = clusters[i].get_average_inserted_sequence_size();
-                if (mate1.orientation == strand::forward)
+                if (mate1.seq_name == mate2.seq_name)
                 {
-                    int32_t distance = mate2_pos - mate1_pos;
-                    //Deletion
-                    if (distance >= args.min_var_length &&
-                        distance <= args.max_var_length &&
-                        insert_size <= args.max_tol_inserted_length)
+                    int32_t mate1_pos = mate1.position;
+                    int32_t mate2_pos = mate2.position;
+                    int32_t insert_size = clusters[i].get_average_inserted_sequence_size();
+                    if (mate1.orientation == strand::forward)
                     {
-                        variant_record tmp{};
-                        tmp.set_chrom(mate1.seq_name);
-                        tmp.set_qual(cluster_size);
-                        tmp.set_alt("<DEL>");
-                        tmp.add_info("SVTYPE", "DEL");
-                        // Increment position by 1 because VCF is 1-based
-                        tmp.set_pos(mate1_pos + 1);
-                        tmp.add_info("SVLEN", std::to_string(-distance + 1));
-                        // Increment end by 1 because VCF is 1-based
-                        // Decrement end by 1 because deletion ends one base before mate2 begins
-                        tmp.add_info("END", std::to_string(mate2_pos));
-                        tmp.print(out_stream);
-                    }
-                    //Insertion
-                    else if (distance == 1 &&
-                             insert_size >= args.min_var_length)
-                    {
-                        variant_record tmp{};
-                        tmp.set_chrom(mate1.seq_name);
-                        tmp.set_qual(cluster_size);
-                        tmp.set_alt("<INS>");
-                        tmp.add_info("SVTYPE", "INS");
-                        // Increment position by 1 because VCF is 1-based
-                        tmp.set_pos(mate1_pos + 1);
-                        tmp.add_info("SVLEN", std::to_string(insert_size));
-                        // Increment end by 1 because VCF is 1-based
-                        tmp.add_info("END", std::to_string(mate1_pos + 1));
-                        tmp.print(out_stream);
+                        int32_t distance = mate2_pos - mate1_pos;
+                        //Deletion
+                        if (distance >= args.min_var_length &&
+                            distance <= args.max_var_length &&
+                            insert_size <= args.max_tol_inserted_length)
+                        {
+                            variant_record tmp{};
+                            tmp.set_chrom(mate1.seq_name);
+                            tmp.set_qual(cluster_size);
+                            tmp.set_alt("<DEL>");
+                            tmp.add_info("SVTYPE", "DEL");
+                            // Increment position by 1 because VCF is 1-based
+                            tmp.set_pos(mate1_pos + 1);
+                            tmp.add_info("SVLEN", std::to_string(-distance + 1));
+                            // Increment end by 1 because VCF is 1-based
+                            // Decrement end by 1 because deletion ends one base before mate2 begins
+                            tmp.add_info("END", std::to_string(mate2_pos));
+                            tmp.print(out_stream);
+                        }
+                        //Insertion
+                        else if (distance == 1 &&
+                                insert_size >= args.min_var_length)
+                        {
+                            variant_record tmp{};
+                            tmp.set_chrom(mate1.seq_name);
+                            tmp.set_qual(cluster_size);
+                            tmp.set_alt("<INS>");
+                            tmp.add_info("SVTYPE", "INS");
+                            // Increment position by 1 because VCF is 1-based
+                            tmp.set_pos(mate1_pos + 1);
+                            tmp.add_info("SVLEN", std::to_string(insert_size));
+                            // Increment end by 1 because VCF is 1-based
+                            tmp.add_info("END", std::to_string(mate1_pos + 1));
+                            tmp.print(out_stream);
+                        }
                     }
                 }
             }

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -103,6 +103,9 @@ std::string const help_page_advanced
     "          Specify the minimum quality (amount of supporting reads) of a\n"
     "          structural variant to be reported in the vcf output file. This value\n"
     "          needs to be non-negative. Default: 1.\n"
+    "    -z, --hierarchical_clustering_cutoff (double)\n"
+    "          Specify the distance cutoff for the hierarchical clustering. This\n"
+    "          value needs to be non-negative. Default: 10.\n"
 };
 
 // std::string expected_res_default
@@ -302,6 +305,20 @@ TEST_F(iGenVar_cli_test, fail_negative_min_qual)
     std::string expected_err
     {
         "[Error] You gave a negative min_qual parameter.\n"
+    };
+    EXPECT_EQ(result.exit_code, 65280);
+    EXPECT_EQ(result.out, std::string{});
+    EXPECT_EQ(result.err, expected_err);
+}
+
+TEST_F(iGenVar_cli_test, fail_negative_hierarchical_clustering_cutoff)
+{
+    cli_test_result result = execute_app("iGenVar",
+                                         "-j", data(default_alignment_long_reads_file_path),
+                                         "-z -30");
+    std::string expected_err
+    {
+        "[Error] You gave a negative hierarchical_clustering_cutoff parameter.\n"
     };
     EXPECT_EQ(result.exit_code, 65280);
     EXPECT_EQ(result.out, std::string{});

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -99,6 +99,10 @@ std::string const help_page_advanced
     "    -p, --max_overlap (signed 32 bit integer)\n"
     "          Specify the maximum allowed overlap between two alignment segments.\n"
     "          This value needs to be non-negative. Default: 10.\n"
+    "    -u, --min_qual (signed 32 bit integer)\n"
+    "          Specify the minimum quality (amount of supporting reads) of a\n"
+    "          structural variant to be reported in the vcf output file. This value\n"
+    "          needs to be non-negative. Default: 1.\n"
 };
 
 // std::string expected_res_default
@@ -284,6 +288,20 @@ TEST_F(iGenVar_cli_test, fail_negative_max_overlap)
     std::string expected_err
     {
         "[Error] You gave a negative max_overlap parameter.\n"
+    };
+    EXPECT_EQ(result.exit_code, 65280);
+    EXPECT_EQ(result.out, std::string{});
+    EXPECT_EQ(result.err, expected_err);
+}
+
+TEST_F(iGenVar_cli_test, fail_negative_min_qual)
+{
+    cli_test_result result = execute_app("iGenVar",
+                                         "-j", data(default_alignment_long_reads_file_path),
+                                         "-u -30");
+    std::string expected_err
+    {
+        "[Error] You gave a negative min_qual parameter.\n"
     };
     EXPECT_EQ(result.exit_code, 65280);
     EXPECT_EQ(result.out, std::string{});


### PR DESCRIPTION
For our very first benchmarks we realized, that these two parameters make a huge difference on our results:
- the filtering cutoff for the sv results (default 1 read)
- the cutoff for the hierarchical clustering (default distance of 10)

Thus I made two commits to add these values to our input parameters:
- [FEATURE] Add a quality input parameter for SVs (amount of supporting reads).
- [FEATURE] Add a clustering cutoff parameter for the hierarchical clustering
