### PR TITLE
[Fix] Subsample large partitions

### DIFF
--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -112,8 +112,6 @@ void detect_variants_in_alignment_file(cmd_arguments const & args)
     // Store junctions
     std::vector<Junction> junctions{};
     std::map<std::string, int32_t> references_lengths{};
-    // Set number of decompression threads
-    seqan3::contrib::bgzf_thread_count = args.threads;
 
     // short reads
     if (args.alignment_short_reads_file_path != "")

--- a/src/variant_detection/variant_detection.cpp
+++ b/src/variant_detection/variant_detection.cpp
@@ -53,6 +53,8 @@ void detect_junctions_in_short_reads_sam_file(std::vector<Junction> & junctions,
                                      seqan3::field::ref_offset, // 4: POS
                                      seqan3::field::mapq>;      // 5: MAPQ
 
+    // Set number of decompression threads
+    seqan3::contrib::bgzf_thread_count = args.threads;
     seqan3::sam_file_input alignment_short_reads_file{args.alignment_short_reads_file_path, my_fields{}};
 
     std::deque<std::string> const ref_ids = read_header_information(alignment_short_reads_file, references_lengths);
@@ -111,6 +113,8 @@ void detect_junctions_in_long_reads_sam_file(std::vector<Junction> & junctions,
                                      seqan3::field::seq,        // 10:SEQ
                                      seqan3::field::tags>;
 
+    // Set number of decompression threads
+    seqan3::contrib::bgzf_thread_count = args.threads;
     seqan3::sam_file_input alignment_long_reads_file{args.alignment_long_reads_file_path, my_fields{}};
 
     std::deque<std::string> const ref_ids = read_header_information(alignment_long_reads_file, references_lengths);

--- a/src/variant_detection/variant_detection.cpp
+++ b/src/variant_detection/variant_detection.cpp
@@ -58,7 +58,7 @@ void detect_junctions_in_short_reads_sam_file(std::vector<Junction> & junctions,
     seqan3::sam_file_input alignment_short_reads_file{args.alignment_short_reads_file_path, my_fields{}};
 
     std::deque<std::string> const ref_ids = read_header_information(alignment_short_reads_file, references_lengths);
-    uint16_t num_good = 0;
+    uint32_t num_good = 0;
 
     for (auto & record : alignment_short_reads_file)
     {
@@ -118,7 +118,7 @@ void detect_junctions_in_long_reads_sam_file(std::vector<Junction> & junctions,
     seqan3::sam_file_input alignment_long_reads_file{args.alignment_long_reads_file_path, my_fields{}};
 
     std::deque<std::string> const ref_ids = read_header_information(alignment_long_reads_file, references_lengths);
-    uint16_t num_good = 0;
+    uint32_t num_good = 0;
 
     for (auto & record : alignment_long_reads_file)
     {

--- a/test/api/clustering_test.cpp
+++ b/test/api/clustering_test.cpp
@@ -428,3 +428,39 @@ TEST(hierarchical_clustering, clustering_25)
         }
     }
 }
+
+TEST(hierarchical_clustering, subsampling)
+{
+    std::vector<Junction> input_junctions;
+    for (int32_t i = 0; i < 300; ++i)
+    {
+        input_junctions.emplace_back(Breakend{chrom1,
+                                              chrom1_position1 + i,
+                                              strand::forward},
+                                     Breakend{chrom2,
+                                              chrom2_position1 + i,
+                                              strand::forward},
+                                     ""_dna5,
+                                     read_name_1);
+    }
+    std::sort(input_junctions.begin(), input_junctions.end());
+    
+    testing::internal::CaptureStderr();
+    std::vector<Cluster> clusters = hierarchical_clustering_method(input_junctions, 0);
+
+    size_t num_junctions = 0;
+    for (Cluster const & cluster : clusters)
+    {
+        num_junctions += cluster.get_cluster_size();
+    }
+    EXPECT_EQ(num_junctions, 200);
+    
+    std::string const expected_err
+    {
+        "A partition exceeds the maximum size (300>200) and has to be subsampled. "
+        "Representative partition member:\n"
+        "[chr1\t12323443\tForward] -> [chr2\t234432\tForward]\n"
+    };
+    std::string result_err = testing::internal::GetCapturedStderr();
+    EXPECT_EQ(expected_err, result_err);
+}


### PR DESCRIPTION
This PR introduces changes for speeding up the hierarchical clustering and therefore fixes #130.

Additionally, this PR fixes two other small problems:
- The setting of the number of decompression threads as introduced in #134 did not work. Probably, the reason is that the variable was set in the method `detect_variants_in_alignment_file()`. With this PR, the number of threads is set in `detect_junctions_in_short_reads_sam_file()` and `detect_junctions_in_long_reads_sam_file()` directly before opening the SAM/BAM files. This now worked in my tests.
- The `num_good` variable counts the number of valid alignments and is used for reporting the progress during runtime. This PR changes its type from uint16_t which was far too small for large SAM/BAM files to uint32_t.