### PR TITLE
[FIX] Interrupted BAMIT creation, which ends in an `cereal::Exception`.

### DIFF
--- a/include/variant_detection/variant_detection.hpp
+++ b/include/variant_detection/variant_detection.hpp
@@ -20,6 +20,14 @@
 std::deque<std::string> read_header_information(auto & alignment_file,
                                                 std::map<std::string, int32_t> & references_lengths);
 
+/*! \brief Support function for a atomic file write operation.\n
+ *         Note: The functionality of the variables is described for BAMIT.
+ *
+ * \param[in] tmp_file_path - tmp file path (ending: `.bit.tmp`)
+ * \param[in] file_path - the path for the BAMIT file (ending: `.bit`)
+ */
+void safe_sync_rename(std::filesystem::path const & tmp_file_path, std::filesystem::path const & file_path);
+
 /*! \brief Attempts to load a bamit index having the same name as a given input file, with ".bit" appended at the end.
  *         If this file does not exist, it will create the index itself and save it to that file.
  *


### PR DESCRIPTION
If a run of iGenVar is aborted in the BAMIT creation, an incorrect index is stored, which cannot be read when iGenVar is called again:
```
terminate called after throwing an instance of 'cereal::Exception'
  what():  Failed to read 8 bytes from input stream! Read 0
Abort trap: 6
```
Fix: We write the index into a tmp file and save it with the correct filename after finishing.