### PR TITLE
[FIX] Remove unnecessary "Number" from ALT header lines

### DIFF
--- a/src/variant_detection/variant_output.cpp
+++ b/src/variant_detection/variant_output.cpp
@@ -43,9 +43,9 @@ void write_header(std::map<std::string, int32_t> & references_lengths,
 
     hdr.other_lines = {"filedate="s + transTime(),
                        "source=iGenVarCaller",
-                       "ALT=<ID=DEL,Number=1,Description=\"Deletion\">",
-                       "ALT=<ID=DUP:TANDEM,Number=1,Description=\"Tandem Duplication\">",
-                       "ALT=<ID=INS,Number=1,Description=\"Insertion of novel sequence\">"};
+                       "ALT=<ID=DEL,Description=\"Deletion\">",
+                       "ALT=<ID=DUP:TANDEM,Description=\"Tandem Duplication\">",
+                       "ALT=<ID=INS,Description=\"Insertion of novel sequence\">"};
     hdr.column_labels = {"CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", sample_name};
 }
 

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -173,9 +173,9 @@ std::string const general_header_lines_2
 {
     "##filedate=\n"             // remove date as it can differ and erase it from the result.out
     "##source=iGenVarCaller\n"
-    "##ALT=<ID=DEL,Number=1,Description=\"Deletion\">\n"
-    "##ALT=<ID=DUP:TANDEM,Number=1,Description=\"Tandem Duplication\">\n"
-    "##ALT=<ID=INS,Number=1,Description=\"Insertion of novel sequence\">\n"
+    "##ALT=<ID=DEL,Description=\"Deletion\">\n"
+    "##ALT=<ID=DUP:TANDEM,Description=\"Tandem Duplication\">\n"
+    "##ALT=<ID=INS,Description=\"Insertion of novel sequence\">\n"
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tMYSAMPLE\n"
 };
 

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -34,7 +34,7 @@ declare_datasource (FILE output_err.txt
 # copies file to <build>/data/output_res.vcf
 declare_datasource (FILE output_res.vcf
                     URL ${CMAKE_SOURCE_DIR}/test/data/mini_example/output_res.vcf
-                    URL_HASH SHA256=245974501fe0b8cfc63873008780c46eec115ecd63f90809b6fa98f2eb6852ca)
+                    URL_HASH SHA256=098fa627a6ba12baa5327d3ded97a3b75fa715d4b3177be5e9eaca1ee727e65d)
 
 # copies file to <build>/data/output_short_and_long_err.txt
 declare_datasource (FILE output_short_and_long_err.txt
@@ -44,4 +44,4 @@ declare_datasource (FILE output_short_and_long_err.txt
 # copies file to <build>/data/output_short_and_long_res.vcf
 declare_datasource (FILE output_short_and_long_res.vcf
                     URL ${CMAKE_SOURCE_DIR}/test/data/mini_example/output_short_and_long_res.vcf
-                    URL_HASH SHA256=b32b53637e93c769f21fd92345cc5194788f44abd8f021778c2624e917e87b3a)
+                    URL_HASH SHA256=d85da83b11a5ebe88832bfdc2cc1db985eda2c05d9e657eb6ba7ff99a4828eed)

--- a/test/data/mini_example/output_res.vcf
+++ b/test/data/mini_example/output_res.vcf
@@ -8,9 +8,9 @@
 ##contig=<ID=chr1,length=482>
 ##filedate=
 ##source=iGenVarCaller
-##ALT=<ID=DEL,Number=1,Description="Deletion">
-##ALT=<ID=DUP:TANDEM,Number=1,Description="Tandem Duplication">
-##ALT=<ID=INS,Number=1,Description="Insertion of novel sequence">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	MYSAMPLE
 chr1	57	.	N	<DEL>	9	PASS	END=70;SVLEN=13;iGenVar_SVLEN=-13;SVTYPE=DEL	GT	./.
 chr1	97	.	N	<DEL>	1	PASS	END=125;SVLEN=28;iGenVar_SVLEN=-28;SVTYPE=DEL	GT	./.

--- a/test/data/mini_example/output_short_and_long_res.vcf
+++ b/test/data/mini_example/output_short_and_long_res.vcf
@@ -8,9 +8,9 @@
 ##contig=<ID=chr1,length=482>
 ##filedate=
 ##source=iGenVarCaller
-##ALT=<ID=DEL,Number=1,Description="Deletion">
-##ALT=<ID=DUP:TANDEM,Number=1,Description="Tandem Duplication">
-##ALT=<ID=INS,Number=1,Description="Insertion of novel sequence">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	MYSAMPLE
 chr1	57	.	N	<DEL>	18	PASS	END=70;SVLEN=13;iGenVar_SVLEN=-13;SVTYPE=DEL	GT	./.
 chr1	97	.	N	<DEL>	1	PASS	END=125;SVLEN=28;iGenVar_SVLEN=-28;SVTYPE=DEL	GT	./.


### PR DESCRIPTION
The picard tool did not accept our vcf. And after a look into the vcf specification I also saw why. The entry Number in the ALT header is unnecessary. 
-> https://samtools.github.io/hts-specs/VCFv4.3.pdf