### PR TITLE
deBruijn graph for haplotype calling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,18 @@ FetchContent_Populate(hclust)
 add_library ("fastcluster" STATIC ${hclust_SOURCE_DIR}/fastcluster.cpp)
 target_include_directories ("fastcluster" PUBLIC ${hclust_SOURCE_DIR})
 
+# Dependency: Lemon Graph Library
+FetchContent_Declare(
+        lemon
+        GIT_REPOSITORY https://github.com/seqan/lemon.git
+        GIT_TAG 400d51cff5b4c4b59dd11a30965b9837a3df7b53
+)
+FetchContent_GetProperties(lemon)
+if (NOT lemon_POPULATED)
+    FetchContent_Populate(lemon)
+    include_directories(SYSTEM ${lemon_SOURCE_DIR}/include)
+endif ()
+
 # Dependency: BAMIntervalTree.
 add_library ("bamit" INTERFACE)
 target_include_directories ("bamit" INTERFACE lib/BAMIntervalTree/include/)

--- a/include/structures/debruijn_graph.hpp
+++ b/include/structures/debruijn_graph.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+
+#include <lemon/maps.h>
+#include <lemon/list_graph.h>
+
+//! \brief A De Bruijn Graph represents overlaps between DNA sequences.
+class DeBruijnGraph
+{
+private:
+    unsigned char len; //!> The length of the sequence fragments in the nodes (k-mer length).
+    std::optional<bool> viable; //!> Flag whether the graph is complex and acyclic. No value means unknown.
+    lemon::ListDigraph graph; //!> The graph structure.
+    lemon::ListDigraph::ArcMap<size_t> arcs; //!> Each arc is assigned the number of reads that support it.
+    lemon::CrossRefMap<lemon::ListDigraph, lemon::ListDigraph::Node, size_t> nodes; //!> Each node represents a k-mer.
+
+public:
+    /*!\name Constructor and destructor
+     * \{
+     */
+    DeBruijnGraph() : len(0), viable(false), graph(), arcs(graph), nodes(graph) {} //!< Defaulted.
+    DeBruijnGraph(DeBruijnGraph const &) = delete; //!< Deleted.
+    DeBruijnGraph(DeBruijnGraph &&) noexcept = delete; //!< Deleted.
+    DeBruijnGraph & operator=(DeBruijnGraph const &) = delete; //!< Deleted.
+    DeBruijnGraph & operator=(DeBruijnGraph &&) noexcept = delete; //!< Deleted.
+    ~DeBruijnGraph() = default; //!< Defaulted.
+    //!\}
+
+    /*!
+     * \brief Reset and initialize the graph with a reference sequence.
+     * \param[in] kmer_len The k-mer length.
+     * \param[in] reference The reference sequence that is added to the graph.
+     * \return whether the reference k-mers are unique. If false, please re-initialize with higher `len`.
+     */
+    bool init_sequence(unsigned char kmer_len, seqan3::dna4_vector const & reference);
+
+    /*!
+     * \brief Add a read sequence to the graph. The `viable` property will be unknown afterwards.
+     * \param[in] read The read sequence.
+     */
+    void add_read(seqan3::dna4_vector const & read);
+
+    /*!
+     * \brief Check if the graph is acyclic (DAG) and complex.
+     * \return whether the graph is viable.
+     *
+     * \details
+     * Complex means: number of non-unique nodes < 4 * number of unique nodes.
+     * If the `viable` property is known, it is returned, otherwise it is computed once.
+     */
+    bool is_viable();
+
+    /*!
+     * \brief Prune arcs that are not well supported by reads. Afterwards, remove nodes that do not have an arc.
+     * \param[in] threshold Arcs with fewer than `threshold` supporting reads are removed.
+     */
+    void prune(size_t threshold);
+
+    /*!
+     * \brief Traverse the graph and collect the haplotype sequences.
+     * \return a vector of haplotype sequences with associated score, sorted by score in descending order.
+     *
+     * \details
+     * The scores add up to 1 and represent the relative read support of the path.
+     */
+    std::vector<std::pair<float, seqan3::dna4_vector>> collect_haplotype_sequences() const;
+
+    /*!
+     * \brief Write the graph in dot format to a file. Can be used to visualize the graph with the dot program.
+     * \param[in] filename The filename of the graph file (usually with suffix .gv).
+     */
+    void export_dot_format(std::string const & filename) const;
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library ("${PROJECT_NAME}_lib" STATIC modules/clustering/hierarchical_cluste
                                           structures/aligned_segment.cpp
                                           structures/breakend.cpp
                                           structures/cluster.cpp
+                                          structures/debruijn_graph.cpp
                                           structures/junction.cpp
                                           variant_detection/method_enums.cpp
                                           variant_detection/snp_indel_detection.cpp

--- a/src/structures/debruijn_graph.cpp
+++ b/src/structures/debruijn_graph.cpp
@@ -1,0 +1,203 @@
+#include <algorithm>
+#include <fstream>
+
+#include <seqan3/search/views/kmer_hash.hpp>
+#include <seqan3/utility/views/to.hpp>
+#include <seqan3/utility/views/zip.hpp>
+
+#include <lemon/connectivity.h>
+#include <lemon/path.h>
+
+#include "structures/debruijn_graph.hpp"
+
+bool DeBruijnGraph::init_sequence(unsigned char kmer_len, seqan3::dna4_vector const & reference)
+{
+    // Initialize the graph.
+    len = kmer_len;
+    viable = false;
+    graph.clear();
+    assert(len <= reference.size());
+    graph.reserveNode(static_cast<int>(reference.size() + 1 - len));
+    graph.reserveArc(static_cast<int>(reference.size() - len));
+
+    lemon::ListDigraph::Node prev_node = lemon::INVALID; // the previously processed node
+    for (size_t kmer : seqan3::views::kmer_hash(reference, seqan3::ungapped{len})) // iterate kmers
+    {
+        if (nodes(kmer) == lemon::INVALID) // the kmer is new
+        {
+            nodes.set(graph.addNode(), kmer); // add node
+            if (prev_node != lemon::INVALID)
+                arcs.set(graph.addArc(prev_node, nodes(kmer)), 0); // add arc
+
+            prev_node = nodes(kmer); // update processed node
+        }
+        else // abort: the kmer already exists (cycle)
+        {
+            len = 0;
+            return false;
+        }
+    }
+    return true;
+}
+
+void DeBruijnGraph::add_read(seqan3::dna4_vector const & read)
+{
+    assert(len > 0); // adding reads to an uninitialized graph is an error
+    lemon::ListDigraph::Node prev_node = lemon::INVALID; // the previously processed node
+    for (size_t kmer : seqan3::views::kmer_hash(read, seqan3::ungapped{len})) // iterate kmers
+    {
+        if (nodes(kmer) == lemon::INVALID) // kmer is not in graph: new node
+            nodes.set(graph.addNode(), kmer);
+
+        if (prev_node != lemon::INVALID)
+        {
+            lemon::ListDigraph::Arc arc = lemon::findArc(graph, prev_node, nodes(kmer));
+            if (arc != lemon::INVALID) // arc exists: increment read count
+                ++arcs[arc];
+            else
+                arcs.set(graph.addArc(prev_node, nodes(kmer)), 1); // new arc
+        }
+        prev_node = nodes(kmer); // update processed node
+    }
+    viable = std::nullopt; // we do not know if graph is viable anymore
+}
+
+bool DeBruijnGraph::is_viable()
+{
+    if (!viable) // status is unknown
+    {
+        if (len == 0 || !lemon::dag(graph)) // graph is uninitialized or has cycles
+        {
+            viable = false;
+        }
+        else // check if graph is complex enough (number of non-unique nodes < 4 * number of unique nodes)
+        {
+            int num_unique{}; // number of unique kmers (0-1 in and out arcs)
+            int num_non_unique{}; // number of non-unique kmers (>1 in or out arcs)
+            for (lemon::ListDigraph::NodeIt node(graph); node != lemon::INVALID; ++node)
+            {
+                lemon::ListDigraph::InArcIt in_arc(graph, node);
+                lemon::ListDigraph::OutArcIt out_arc(graph, node);
+                bool in = in_arc == lemon::INVALID || (arcs[in_arc] < 2 && ++in_arc == lemon::INVALID);
+                bool out = out_arc == lemon::INVALID || (arcs[out_arc] < 2 && ++out_arc == lemon::INVALID);
+                if (in && out)
+                    ++num_unique;
+                else
+                    ++num_non_unique;
+            }
+            viable = num_non_unique < 4 * num_unique;
+        }
+    }
+    return *viable;
+}
+
+void DeBruijnGraph::prune(size_t threshold)
+{
+    // We need to store the nodes and arcs to be deleted, because the iterator gets confused otherwise.
+
+    { // Erase each arc with read support below threshold.
+        std::vector<lemon::ListDigraph::Arc> del;
+        for (lemon::ListDigraph::ArcIt arc(graph); arc != lemon::INVALID; ++arc)
+            if (arcs[arc] < threshold)
+                del.push_back(arc);
+
+        for (auto const & arc : del)
+            graph.erase(arc);
+    }
+
+    { // Erase unconnected nodes.
+        std::vector<lemon::ListDigraph::Node> del;
+        for (lemon::ListDigraph::NodeIt node(graph); node != lemon::INVALID; ++node)
+        {
+            if (lemon::ListDigraph::OutArcIt(graph, node) == lemon::INVALID &&
+                lemon::ListDigraph::InArcIt(graph, node) == lemon::INVALID)
+                del.push_back(node);
+        }
+
+        for (auto const & node : del)
+            graph.erase(node);
+    }
+}
+
+std::vector<std::pair<float, seqan3::dna4_vector>> DeBruijnGraph::collect_haplotype_sequences() const
+{
+    // We do a depth-first search (dfs) in order to traverse all possible paths.
+    lemon::Dfs<lemon::ListDigraph> dfs(graph);
+    dfs.init();
+
+    // Find all source nodes: they have no incoming arcs. Build a map of the out-degrees for each node.
+    lemon::ListDigraph::NodeMap<size_t> out_degree(graph, 0);
+    for (lemon::ListDigraph::NodeIt node(graph); node != lemon::INVALID; ++node)
+    {
+        if (lemon::ListDigraph::InArcIt(graph, node) == lemon::INVALID)
+            dfs.addSource(node);
+        for (lemon::ListDigraph::OutArcIt arc(graph, node); arc != lemon::INVALID; ++arc)
+            out_degree[node] += arcs[arc];
+    }
+
+    // Storage for all the paths. Paths can be static, because only complete paths are stored here.
+    std::vector<lemon::StaticPath<lemon::ListDigraph>> paths;
+    {
+        lemon::SimplePath<lemon::ListDigraph> path; // the currently constructed path
+        lemon::ListDigraph::Node prev_node = graph.source(dfs.nextArc()); // the previously processed node
+
+        while (!dfs.emptyQueue())
+        {
+            lemon::ListDigraph::Arc arc = dfs.processNextArc(); // go to next arc
+            if (graph.source(arc) != prev_node) // we have jumped back to a fork
+            {
+                paths.emplace_back(path); // store the path that was completed before the jump
+                while (!path.empty() && graph.target(path.back()) != graph.source(arc))
+                    path.eraseBack(); // delete backwards until fork: the prefix is still needed for the next path
+            }
+            path.addBack(arc); // add to the current path
+            prev_node = graph.target(arc); // update the processed node
+        }
+        paths.emplace_back(path); // store the last path that is completed when dfs finishes
+        assert(lemon::checkPath(graph, path));
+    }
+
+    // For each path: collect sequence and score.
+    std::vector<std::pair<float, seqan3::dna4_vector>> haplotypes(paths.size());
+    for (auto && [path, haplotype] : seqan3::views::zip(paths, haplotypes))
+    {
+        auto && [score, seq] = haplotype;
+        score = 1; // we will multiply the score, so start with 1
+        seq.resize(path.length() + len); // allocate the haplotype sequence length
+
+        // Convert the first node's kmer hash into sequence.
+        size_t const hash = nodes[lemon::pathSource(graph, path)];
+        for (unsigned char idx = 0; idx < len; ++idx)
+            seq[idx].assign_rank(hash >> 2 * (len - idx - 1) & 0b11);
+
+        // Iterate the path and collect further sequence characters.
+        size_t idx = len;
+        for (lemon::StaticPath<lemon::ListDigraph>::ArcIt arc(path); arc != lemon::INVALID; ++arc, ++idx)
+        {
+            seq[idx].assign_rank(nodes[graph.target(arc)] & 0b11);
+            score *= static_cast<float>(arcs[arc]) / static_cast<float>(out_degree[graph.source(arc)]);
+        }
+    }
+    std::sort(haplotypes.rbegin(), haplotypes.rend()); // highest score first
+    return haplotypes;
+}
+
+void DeBruijnGraph::export_dot_format(std::string const & filename) const
+{
+    std::ofstream ofs(filename);
+    ofs << "digraph G {\n";
+    for (lemon::ListDigraph::NodeIt node(graph); node != lemon::INVALID; ++node)
+    {
+        // generate label
+        std::string label;
+        label.resize(len);
+        for (unsigned char idx = 0; idx < len; ++idx)
+            label[idx] = seqan3::dna4{}.assign_rank(nodes[node] >> 2 * (len - idx - 1) & 0b11).to_char();
+
+        // produce output
+        ofs << nodes[node] << " [label=\"" << label << "\"];\n";
+        for (lemon::ListDigraph::OutArcIt arc(graph, node); arc != lemon::INVALID; ++arc)
+            ofs << nodes[node] << " -> " << nodes[graph.runningNode(arc)] << " [label=\"" << arcs[arc] << "\"];\n";
+    }
+    ofs << "}\n";
+}

--- a/src/structures/debruijn_graph.cpp
+++ b/src/structures/debruijn_graph.cpp
@@ -78,8 +78,10 @@ bool DeBruijnGraph::is_viable()
             {
                 lemon::ListDigraph::InArcIt in_arc(graph, node);
                 lemon::ListDigraph::OutArcIt out_arc(graph, node);
+                // true if the node has either no ingoing arc, or exactly one arc with 1 or 0 supporting reads
                 bool in = in_arc == lemon::INVALID || (arcs[in_arc] < 2 && ++in_arc == lemon::INVALID);
                 bool out = out_arc == lemon::INVALID || (arcs[out_arc] < 2 && ++out_arc == lemon::INVALID);
+                // a node is unique if for ingoing and outgoing arcs there is at most 1 supporting read
                 if (in && out)
                     ++num_unique;
                 else

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required (VERSION 3.11)
 add_api_test (input_file_test.cpp)
 target_use_datasources (input_file_test FILES simulated.minimap2.hg19.coordsorted_cutoff.sam)
 
+add_api_test (debruijn_graph_test.cpp)
+
 add_api_test (detection_test.cpp)
 
 add_api_test (clustering_test.cpp)

--- a/test/api/debruijn_graph_test.cpp
+++ b/test/api/debruijn_graph_test.cpp
@@ -19,12 +19,6 @@ TEST(debruijn_graph, init)
     // the k-mer CG occurs twice
     EXPECT_FALSE(graph.init_sequence(2, "CGTCG"_dna4));
 
-    // len = 0
-    EXPECT_DEBUG_DEATH(graph.init_sequence(0, "CGTCG"_dna4), "k.value > 0");
-
-    // sequence longer than k
-    EXPECT_DEBUG_DEATH(graph.init_sequence(10, "CGTCG"_dna4), "len <= reference.size");
-
     // sequence as long as k
     EXPECT_TRUE(graph.init_sequence(5, "CGTCG"_dna4));
     EXPECT_FALSE(graph.is_viable());

--- a/test/api/debruijn_graph_test.cpp
+++ b/test/api/debruijn_graph_test.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iterator>
+
+#include "structures/debruijn_graph.hpp"
+
+TEST(debruijn_graph, empty)
+{
+    DeBruijnGraph graph;
+    EXPECT_FALSE(graph.is_viable());
+}
+
+TEST(debruijn_graph, init)
+{
+    using namespace seqan3::literals;
+    DeBruijnGraph graph;
+
+    // the k-mer CG occurs twice
+    EXPECT_FALSE(graph.init_sequence(2, "CGTCG"_dna4));
+
+    // len = 0
+    EXPECT_DEBUG_DEATH(graph.init_sequence(0, "CGTCG"_dna4), "k.value > 0");
+
+    // sequence longer than k
+    EXPECT_DEBUG_DEATH(graph.init_sequence(10, "CGTCG"_dna4), "len <= reference.size");
+
+    // sequence as long as k
+    EXPECT_TRUE(graph.init_sequence(5, "CGTCG"_dna4));
+    EXPECT_FALSE(graph.is_viable());
+
+    // sequence longer than k
+    EXPECT_TRUE(graph.init_sequence(10, "CGTCGAAAATCAT"_dna4));
+    EXPECT_FALSE(graph.is_viable());
+}
+
+TEST(debruijn_graph, haplotypes)
+{
+    using namespace seqan3::literals;
+    DeBruijnGraph graph;
+    EXPECT_TRUE(graph.init_sequence(4, "AAAACCCCGGGGUUUU"_dna4));
+    EXPECT_FALSE(graph.is_viable());
+
+    // add reads
+    graph.add_read("AAAACCCCUUUU"_dna4);
+    graph.add_read("AAAACCCCUUUU"_dna4);
+    graph.add_read("AAAAGGGGUUUU"_dna4);
+    graph.add_read("AAAAGGGGUUUU"_dna4);
+    // not enough unique reads
+    EXPECT_FALSE(graph.is_viable());
+    graph.add_read("AUGC"_dna4); // add another unique k-mer
+    graph.add_read("AUCG"_dna4); // add another unique k-mer
+    EXPECT_TRUE(graph.is_viable());
+
+    // 5 k-mers occur only once, prune them: CCCG CCGG CGGG AUGC AUCG
+    graph.prune(2);
+    auto haplotypes = graph.collect_haplotype_sequences();
+    EXPECT_EQ(haplotypes.size(), 2U);
+
+    EXPECT_FLOAT_EQ(haplotypes.front().first, .5F);
+    EXPECT_EQ(haplotypes.front().second, "AAAAGGGGUUUU"_dna4);
+    EXPECT_FLOAT_EQ(haplotypes.back().first, .5F);
+    EXPECT_EQ(haplotypes.back().second, "AAAACCCCUUUU"_dna4);
+
+    // export
+    EXPECT_NO_THROW(graph.export_dot_format("final_graph.gv"));
+    std::ifstream ifs("final_graph.gv");
+    std::string file((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    std::string expected = "digraph G {\n"
+                           "42 [label=\"AGGG\"];\n"
+                           "42 -> 170 [label=\"2\"];\n"
+                           "10 [label=\"AAGG\"];\n"
+                           "10 -> 42 [label=\"2\"];\n"
+                           "2 [label=\"AAAG\"];\n"
+                           "2 -> 10 [label=\"2\"];\n"
+                           "127 [label=\"CTTT\"];\n"
+                           "127 -> 255 [label=\"2\"];\n"
+                           "95 [label=\"CCTT\"];\n"
+                           "95 -> 127 [label=\"2\"];\n"
+                           "87 [label=\"CCCT\"];\n"
+                           "87 -> 95 [label=\"2\"];\n"
+                           "255 [label=\"TTTT\"];\n"
+                           "191 [label=\"GTTT\"];\n"
+                           "191 -> 255 [label=\"2\"];\n"
+                           "175 [label=\"GGTT\"];\n"
+                           "175 -> 191 [label=\"2\"];\n"
+                           "171 [label=\"GGGT\"];\n"
+                           "171 -> 175 [label=\"2\"];\n"
+                           "170 [label=\"GGGG\"];\n"
+                           "170 -> 171 [label=\"2\"];\n"
+                           "85 [label=\"CCCC\"];\n"
+                           "85 -> 87 [label=\"2\"];\n"
+                           "21 [label=\"ACCC\"];\n"
+                           "21 -> 85 [label=\"2\"];\n"
+                           "5 [label=\"AACC\"];\n"
+                           "5 -> 21 [label=\"2\"];\n"
+                           "1 [label=\"AAAC\"];\n"
+                           "1 -> 5 [label=\"2\"];\n"
+                           "0 [label=\"AAAA\"];\n"
+                           "0 -> 2 [label=\"2\"];\n"
+                           "0 -> 1 [label=\"2\"];\n"
+                           "}\n";
+    EXPECT_EQ(file, expected);
+}

--- a/test/api/debruijn_graph_test.cpp
+++ b/test/api/debruijn_graph_test.cpp
@@ -24,7 +24,7 @@ TEST(debruijn_graph, init)
     EXPECT_FALSE(graph.is_viable());
 
     // sequence longer than k
-    EXPECT_TRUE(graph.init_sequence(10, "CGTCGAAAATCAT"_dna4));
+    EXPECT_TRUE(graph.init_sequence(4, "CGTCG"_dna4));
     EXPECT_FALSE(graph.is_viable());
 }
 


### PR DESCRIPTION
This PR implements a deBruijn graph that can be used for calling haplotypes from short reads with respect to a reference sequence. Inline documentation and tests are included. The program that uses this data structure is supposed to perform the following steps:
- initialize an empty graph with a reference sequence
- add reads
- check whether the graph is viable (has enough unique kmers and no loops)
- prune nodes and edges with limited support
- retrieve the haplotype sequences

For debugging and other purposes, the graph can be exported into a formatted file, so it can be visualized with the `dot` program. I'm using the LEMON graph library for implementing the graph. 