### PR TITLE
[MISC] Update SeqAn3 and use sharg parser

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.16.0
-  SEQAN3_NO_VERSION_CHECK: 1
+  CMAKE_VERSION: 3.16.9
+  SHARG_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 
 defaults:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.16.0
-  SEQAN3_NO_VERSION_CHECK: 1
+  CMAKE_VERSION: 3.16.9
+  SHARG_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 
 defaults:

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  SEQAN3_NO_VERSION_CHECK: 1
+  SHARG_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 
 defaults:
@@ -30,7 +30,7 @@ jobs:
             build: documentation
             build_threads: 2
             test_threads: 2
-            cmake: 3.16.0
+            cmake: 3.16.9
             doxygen: 1.9.3
             requires_toolchain: true
             requires_ccache: false

--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <seqan3/argument_parser/argument_parser.hpp>   // for seqan3::argument_parser
+#include <sharg/parser.hpp>                     // for the SeqAn3 sharg::parser
 
-#include "variant_detection/method_enums.hpp"           // for enum detection_methods, clustering_methods and refinement_methods
+#include "variant_detection/method_enums.hpp"   // for enum detection_methods, clustering_methods and refinement_methods
 
 inline bool gVerbose{false};
 
@@ -40,7 +40,7 @@ struct cmd_arguments
     /* y, z? */
 };
 
-void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args);
+void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args);
 
 /*! \brief Detects genomic variants by analyzing an alignment file (sam/bam). The detected
  *         variants are printed to a given file or stdout and insertion alleles are stored in a FASTA file.

--- a/include/iGenVar.hpp
+++ b/include/iGenVar.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <sharg/parser.hpp>                     // for the SeqAn3 sharg::parser
+#include <sharg/parser.hpp>                     // for the SeqAn sharg::parser
 
 #include "variant_detection/method_enums.hpp"   // for enum detection_methods, clustering_methods and refinement_methods
 

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -58,20 +58,18 @@ void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args)
     parser.info.url = "https://github.com/seqan/iGenVar/";
 
     // Options - Input / Output:
+    parser.add_subsection("Input / Output");
     parser.add_option(args.alignment_short_reads_file_path, sharg::config{
                         .short_id = 'i', .long_id = "input_short_reads",
                         .description = "Input short read alignments in SAM or BAM format (Illumina).",
-                        .advanced = false,
                         .validator = sharg::input_file_validator{{"sam", "bam"}} });
     parser.add_option(args.alignment_long_reads_file_path, sharg::config{
                         .short_id = 'j', .long_id = "input_long_reads",
                         .description = "Input long read alignments in SAM or BAM format (PacBio, Oxford Nanopore, ...).",
-                        .advanced = false,
                         .validator = sharg::input_file_validator{{"sam", "bam"}} });
     parser.add_option(args.genome_file_path, sharg::config{
                         .short_id = 'g', .long_id = "input_genome",
                         .description = "Input the sequence of the reference genome.",
-                        .advanced = false,
                         .validator = sharg::input_file_validator{combined_extensions}});
     parser.add_option(args.output_file_path, sharg::config{
                         .short_id = 'o', .long_id = "output",
@@ -79,22 +77,23 @@ void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args)
                         .validator = sharg::output_file_validator{sharg::output_file_open_options::open_or_create, {"vcf"}}});
 
     // Options - VCF:
+    parser.add_subsection("VCF");
     parser.add_option(args.vcf_sample_name, sharg::config{
                         .short_id = 's', .long_id = "vcf_sample_name",
-                        .description = "Specify your sample name for the vcf header line.",
-                        .advanced = false});
+                        .description = "Specify your sample name for the vcf header line."});
 
     // Options - Other parameters:
+    parser.add_subsection("Other parameters");
     parser.add_option(args.threads, sharg::config{
                         .short_id = 't', .long_id = "threads",
-                        .description = "Specify the number of decompression threads used for reading BAM files.",
-                        .advanced = false});
+                        .description = "Specify the number of decompression threads used for reading BAM files."});
     parser.add_flag(gVerbose, sharg::config{
                         .short_id = 'v', .long_id = "verbose",
                         .description = "If you set this flag, we provide additional details about what iGenVar does. "
                                        "The detailed output is printed in the standard error."});
 
     // Options - Optional output:
+    parser.add_subsection("Optional output");
     parser.add_option(args.junctions_file_path, sharg::config{
                         .short_id = 'a', .long_id = "junctions",
                         .description = "The path of the optional junction output file. If no path is given, junctions will not be output.",
@@ -107,6 +106,7 @@ void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args)
                         .validator = sharg::output_file_validator{sharg::output_file_open_options::open_or_create}});
 
     // Options - Methods:
+    parser.add_subsection("Methods");
     parser.add_option(args.methods, sharg::config{
                         .short_id = 'd', .long_id = "method",
                         .description = "Choose the detection method(s) to be used. "
@@ -127,6 +127,7 @@ void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args)
                         .advanced = true});
 
     // Options - SV specifications:
+    parser.add_subsection("SV specifications");
     parser.add_option(args.min_var_length, sharg::config{
                         .short_id = 'k', .long_id = "min_var_length",
                         .description = "Specify what should be the minimum length of your SVs to be detected. "
@@ -160,6 +161,7 @@ void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args)
                         .advanced = true});
 
     // Options - Clustering specifications:
+    parser.add_subsection("Clustering specifications");
     parser.add_option(args.partition_max_distance, sharg::config{
                         .short_id = 'p', .long_id = "partition_max_distance",
                         .description = "Specify the maximum distance in bp between members of the same partition."

--- a/src/iGenVar.cpp
+++ b/src/iGenVar.cpp
@@ -13,116 +13,163 @@
 #include "variant_detection/variant_detection.hpp"                  // for detect_junctions_in_long_reads_sam_file()
 #include "variant_detection/variant_output.hpp"                     // for find_and_output_variants()
 
-void initialize_argument_parser(seqan3::argument_parser & parser, cmd_arguments & args)
+static inline std::vector<std::string> sequence_extensions{
+    seqan3::detail::valid_file_extensions<typename seqan3::sequence_file_input<>::valid_formats>()};
+
+static inline std::vector<std::string> compression_extensions{[]()
+                                                              {
+                                                                  std::vector<std::string> result;
+#ifdef SEQAN3_HAS_BZIP2
+                                                                  result.push_back("bz2");
+#endif
+#ifdef SEQAN3_HAS_ZLIB
+                                                                  result.push_back("gz");
+                                                                  result.push_back("bgzf");
+#endif
+                                                                  return result;
+                                                              }()}; // GCOVR_EXCL_LINE
+
+static inline std::vector<std::string> combined_extensions{
+    []()
+    {
+        if (compression_extensions.empty())
+            return sequence_extensions; // GCOVR_EXCL_LINE
+        std::vector<std::string> result;
+        for (auto && sequence_extension : sequence_extensions)
+        {
+            result.push_back(sequence_extension);
+            for (auto && compression_extension : compression_extensions)
+                result.push_back(sequence_extension + std::string{'.'} + compression_extension);
+        }
+        return result;
+    }()};
+
+void initialize_argument_parser(sharg::parser & parser, cmd_arguments & args)
 {
     parser.info.author = "Lydia Buntrock, David Heller, Joshua Kim";
     parser.info.app_name = "iGenVar";
     parser.info.man_page_title = "Short and Long Read SV Caller";
     parser.info.short_description = "Detect genomic variants in a read alignment file";
     parser.info.version = "0.0.3";
-    parser.info.date = "30-03-2021";    // last update
+    parser.info.date = "11-07-2022";    // last update
     parser.info.email = "lydia.buntrock@fu-berlin.de";
     parser.info.long_copyright = "long_copyright";
     parser.info.short_copyright = "short_copyright";
     parser.info.url = "https://github.com/seqan/iGenVar/";
 
     // Options - Input / Output:
-    parser.add_option(args.alignment_short_reads_file_path,
-                      'i', "input_short_reads",
-                      "Input short read alignments in SAM or BAM format (Illumina).",
-                      seqan3::option_spec::standard,
-                      seqan3::input_file_validator{{"sam", "bam"}} );
-    parser.add_option(args.alignment_long_reads_file_path,
-                      'j', "input_long_reads",
-                      "Input long read alignments in SAM or BAM format (PacBio, Oxford Nanopore, ...).",
-                      seqan3::option_spec::standard,
-                      seqan3::input_file_validator{{"sam", "bam"}} );
-    parser.add_option(args.genome_file_path,
-                      'g', "input_genome",
-                      "Input the sequence of the reference genome.",
-                      seqan3::option_spec::standard,
-                      seqan3::input_file_validator<seqan3::sequence_file_input<>>{} );
-    parser.add_option(args.output_file_path, 'o', "output",
-                      "The path of the vcf output file. If no path is given, will output to standard output.",
-                      seqan3::option_spec::standard,
-                      seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create, {"vcf"}});
+    parser.add_option(args.alignment_short_reads_file_path, sharg::config{
+                        .short_id = 'i', .long_id = "input_short_reads",
+                        .description = "Input short read alignments in SAM or BAM format (Illumina).",
+                        .advanced = false,
+                        .validator = sharg::input_file_validator{{"sam", "bam"}} });
+    parser.add_option(args.alignment_long_reads_file_path, sharg::config{
+                        .short_id = 'j', .long_id = "input_long_reads",
+                        .description = "Input long read alignments in SAM or BAM format (PacBio, Oxford Nanopore, ...).",
+                        .advanced = false,
+                        .validator = sharg::input_file_validator{{"sam", "bam"}} });
+    parser.add_option(args.genome_file_path, sharg::config{
+                        .short_id = 'g', .long_id = "input_genome",
+                        .description = "Input the sequence of the reference genome.",
+                        .advanced = false,
+                        .validator = sharg::input_file_validator{combined_extensions}});
+    parser.add_option(args.output_file_path, sharg::config{
+                        .short_id = 'o', .long_id = "output",
+                        .description = "The path of the vcf output file. If no path is given, will output to standard output.",
+                        .validator = sharg::output_file_validator{sharg::output_file_open_options::open_or_create, {"vcf"}}});
 
     // Options - VCF:
-    parser.add_option(args.vcf_sample_name, 's', "vcf_sample_name",
-                      "Specify your sample name for the vcf header line.",
-                      seqan3::option_spec::standard);
+    parser.add_option(args.vcf_sample_name, sharg::config{
+                        .short_id = 's', .long_id = "vcf_sample_name",
+                        .description = "Specify your sample name for the vcf header line.",
+                        .advanced = false});
 
     // Options - Other parameters:
-    parser.add_option(args.threads, 't', "threads",
-                      "Specify the number of decompression threads used for reading BAM files.",
-                      seqan3::option_spec::standard);
-    parser.add_flag(gVerbose, 'v', "verbose",
-                    "If you set this flag, we provide additional details about what iGenVar does. The detailed output "
-                    "is printed in the standard error.");
+    parser.add_option(args.threads, sharg::config{
+                        .short_id = 't', .long_id = "threads",
+                        .description = "Specify the number of decompression threads used for reading BAM files.",
+                        .advanced = false});
+    parser.add_flag(gVerbose, sharg::config{
+                        .short_id = 'v', .long_id = "verbose",
+                        .description = "If you set this flag, we provide additional details about what iGenVar does. "
+                                       "The detailed output is printed in the standard error."});
 
     // Options - Optional output:
-    parser.add_option(args.junctions_file_path, 'a', "junctions",
-                      "The path of the optional junction output file. If no path is given, junctions will not be output.",
-                      seqan3::option_spec::advanced,
-                      seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create});
-    parser.add_option(args.clusters_file_path, 'b', "clusters",
-                      "The path of the optional cluster output file. If no path is given, clusters will not be output.",
-                      seqan3::option_spec::advanced,
-                      seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create});
+    parser.add_option(args.junctions_file_path, sharg::config{
+                        .short_id = 'a', .long_id = "junctions",
+                        .description = "The path of the optional junction output file. If no path is given, junctions will not be output.",
+                        .advanced = true,
+                        .validator = sharg::output_file_validator{sharg::output_file_open_options::open_or_create}});
+    parser.add_option(args.clusters_file_path, sharg::config{
+                        .short_id = 'b', .long_id = "clusters",
+                        .description = "The path of the optional cluster output file. If no path is given, clusters will not be output.",
+                        .advanced = true,
+                        .validator = sharg::output_file_validator{sharg::output_file_open_options::open_or_create}});
 
     // Options - Methods:
-    parser.add_option(args.methods, 'd', "method",
-                      "Choose the detection method(s) to be used. "
-                      "Value must be one of (method name or number) "
-                      "[0,cigar_string,1,split_read,2,read_pairs,3,read_depth].",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.clustering_method, 'c', "clustering_method",
-                      "Choose the clustering method to be used. "
-                      "Value must be one of (method name or number) [0,simple_clustering,"
-                      "1,hierarchical_clustering,2,self_balancing_binary_tree,3,candidate_selection_based_on_voting].",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.refinement_method, 'r', "refinement_method",
-                      "Choose the refinement method to be used. "
-                      "Value must be one of (method name or number) "
-                      "[0,no_refinement,1,sViper_refinement_method,2,sVirl_refinement_method].",
-                      seqan3::option_spec::advanced);
+    parser.add_option(args.methods, sharg::config{
+                        .short_id = 'd', .long_id = "method",
+                        .description = "Choose the detection method(s) to be used. "
+                                       "Value must be one of (method name or number) "
+                                       "[0,cigar_string,1,split_read,2,read_pairs,3,read_depth].",
+                        .advanced = true});
+    parser.add_option(args.clustering_method, sharg::config{
+                        .short_id = 'c', .long_id = "clustering_method",
+                        .description = "Choose the clustering method to be used. Value must be one of "
+                                       "(method name or number) [0,simple_clustering,1,hierarchical_clustering,"
+                                       "2,self_balancing_binary_tree,3,candidate_selection_based_on_voting].",
+                        .advanced = true});
+    parser.add_option(args.refinement_method, sharg::config{
+                        .short_id = 'r', .long_id = "refinement_method",
+                        .description = "Choose the refinement method to be used. "
+                                       "Value must be one of (method name or number) "
+                                       "[0,no_refinement,1,sViper_refinement_method,2,sVirl_refinement_method].",
+                        .advanced = true});
 
     // Options - SV specifications:
-    parser.add_option(args.min_var_length, 'k', "min_var_length",
-                      "Specify what should be the minimum length of your SVs to be detected. "
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.max_var_length, 'l', "max_var_length",
-                      "Specify what should be the maximum length of your SVs to be detected. "
-                      "SVs larger than this threshold can still be output as translocations. "
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.max_tol_inserted_length, 'm', "max_tol_inserted_length",
-                      "Specify what should be the longest tolerated inserted sequence at sites of DEL SVs. "
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.max_tol_deleted_length, 'e', "max_tol_deleted_length",
-                      "Specify what should be the longest tolerated deleted sequence at sites of non-DEL/INV SVs. "
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.max_overlap, 'n', "max_overlap",
-                      "Specify the maximum allowed overlap between two alignment segments. "
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.min_qual, 'q', "min_qual",
-                      "Specify the minimum quality (amount of supporting reads) of a structural variant to be reported "
-                      "in the vcf output file. This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
+    parser.add_option(args.min_var_length, sharg::config{
+                        .short_id = 'k', .long_id = "min_var_length",
+                        .description = "Specify what should be the minimum length of your SVs to be detected. "
+                                       "This value needs to be non-negative.",
+                        .advanced = true});
+    parser.add_option(args.max_var_length, sharg::config{
+                        .short_id = 'l', .long_id = "max_var_length",
+                        .description = "Specify what should be the maximum length of your SVs to be detected. "
+                                       "SVs larger than this threshold can still be output as translocations. "
+                                       "This value needs to be non-negative.",
+                        .advanced = true});
+    parser.add_option(args.max_tol_inserted_length, sharg::config{
+                        .short_id = 'm', .long_id = "max_tol_inserted_length",
+                        .description = "Specify what should be the longest tolerated inserted sequence at sites of DEL "
+                                       "SVs. This value needs to be non-negative.",
+                        .advanced = true});
+    parser.add_option(args.max_tol_deleted_length, sharg::config{
+                        .short_id = 'e', .long_id = "max_tol_deleted_length",
+                        .description = "Specify what should be the longest tolerated deleted sequence at sites of "
+                                       "non-DEL/INV SVs. This value needs to be non-negative.",
+                        .advanced = true});
+    parser.add_option(args.max_overlap, sharg::config{
+                        .short_id = 'n', .long_id = "max_overlap",
+                        .description = "Specify the maximum allowed overlap between two alignment segments. "
+                                       "This value needs to be non-negative.",
+                        .advanced = true});
+    parser.add_option(args.min_qual, sharg::config{
+                        .short_id = 'q', .long_id = "min_qual",
+                        .description = "Specify the minimum quality (amount of supporting reads) of a structural variant "
+                                       "to be reported in the vcf output file. This value needs to be non-negative.",
+                        .advanced = true});
 
     // Options - Clustering specifications:
-    parser.add_option(args.partition_max_distance, 'p', "partition_max_distance",
-                      "Specify the maximum distance in bp between members of the same partition."
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
-    parser.add_option(args.hierarchical_clustering_cutoff, 'w', "hierarchical_clustering_cutoff",
-                      "Specify the distance cutoff for the hierarchical clustering. "
-                      "This value needs to be non-negative.",
-                      seqan3::option_spec::advanced);
+    parser.add_option(args.partition_max_distance, sharg::config{
+                        .short_id = 'p', .long_id = "partition_max_distance",
+                        .description = "Specify the maximum distance in bp between members of the same partition."
+                                       "This value needs to be non-negative.",
+                        .advanced = true});
+    parser.add_option(args.hierarchical_clustering_cutoff, sharg::config{
+                        .short_id = 'w', .long_id = "hierarchical_clustering_cutoff",
+                        .description = "Specify the distance cutoff for the hierarchical clustering. "
+                                       "This value needs to be non-negative.",
+                        .advanced = true});
 }
 
 void detect_variants_in_alignment_file(cmd_arguments const & args)
@@ -238,18 +285,18 @@ void detect_variants_in_alignment_file(cmd_arguments const & args)
 
 int main(int argc, char ** argv)
 {
-    seqan3::argument_parser myparser{"iGenVar", argc, argv};    // initialise myparser
+    sharg::parser parser{"iGenVar", argc, argv};                    // initialise myparser
     cmd_arguments args{};
-    initialize_argument_parser(myparser, args);
+    initialize_argument_parser(parser, args);
 
     // Parse the given arguments and catch possible errors.
     try
     {
-        myparser.parse();                                               // trigger command line parsing
+        parser.parse();                                             // trigger command line parsing
     }
-    catch (seqan3::argument_parser_error const & ext)                   // catch user errors
+    catch (sharg::parser_error const & ext)                         // catch user errors
     {
-        seqan3::debug_stream << "[Error] " << ext.what() << '\n';       // customise your error message
+        seqan3::debug_stream << "[Error] " << ext.what() << '\n';   // customise your error message
         return -1;
     }
 

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -36,7 +36,7 @@ protected:
 
         // Assemble the command string and disable version check.
         std::ostringstream command{};
-        command << "SEQAN3_NO_VERSION_CHECK=1 " << BINDIR;
+        command << "SHARG_NO_VERSION_CHECK=1 " << BINDIR;
         int a[] = {0, ((void)(command << command_items << ' '), 0) ... };
         (void) a;
 

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -42,8 +42,14 @@ std::string const help_page_part_1
     "    -g, --input_genome (std::filesystem::path)\n"
     "          Input the sequence of the reference genome. Default: \"\". The input\n"
     "          file must exist and read permissions must be granted. Valid file\n"
-    "          extensions are: [embl, fasta, fa, fna, ffn, faa, frn, fas, fastq,\n"
-    "          fq, genbank, gb, gbk, sam].\n"
+    "          extensions are: [embl, embl.bz2, embl.gz, embl.bgzf, fasta,\n"
+    "          fasta.bz2, fasta.gz, fasta.bgzf, fa, fa.bz2, fa.gz, fa.bgzf, fna,\n"
+    "          fna.bz2, fna.gz, fna.bgzf, ffn, ffn.bz2, ffn.gz, ffn.bgzf, faa,\n"
+    "          faa.bz2, faa.gz, faa.bgzf, frn, frn.bz2, frn.gz, frn.bgzf, fas,\n"
+    "          fas.bz2, fas.gz, fas.bgzf, fastq, fastq.bz2, fastq.gz, fastq.bgzf,\n"
+    "          fq, fq.bz2, fq.gz, fq.bgzf, genbank, genbank.bz2, genbank.gz,\n"
+    "          genbank.bgzf, gb, gb.bz2, gb.gz, gb.bgzf, gbk, gbk.bz2, gbk.gz,\n"
+    "          gbk.bgzf, sam, sam.bz2, sam.gz, sam.bgzf].\n"
     "    -o, --output (std::filesystem::path)\n"
     "          The path of the vcf output file. If no path is given, will output to\n"
     "          standard output. Default: \"\". Write permissions must be granted.\n"
@@ -62,9 +68,9 @@ std::string const help_page_part_2
 {
     "\n"
     "VERSION\n"
-    "    Last update: 30-03-2021\n"
+    "    Last update: 11-07-2022\n"
     "    iGenVar version: 0.0.3\n"
-    "    SeqAn version: 3.3.0-rc.1\n"
+    "    Sharg version: 0.1.0\n"
     "\n"
     "URL\n"
     "    https://github.com/seqan/iGenVar/\n"
@@ -73,7 +79,7 @@ std::string const help_page_part_2
     "    iGenVar Copyright: short_copyright\n"
     "    Author: Lydia Buntrock, David Heller, Joshua Kim\n"
     "    Contact: lydia.buntrock@fu-berlin.de\n"
-    "    SeqAn Copyright: 2006-2022 Knut Reinert, FU-Berlin; released under the\n"
+    "    SeqAn Copyright: 2006-2021 Knut Reinert, FU-Berlin; released under the\n"
     "    3-clause BSDL.\n"
     "    For full copyright and/or warranty information see --copyright.\n"
 };
@@ -92,7 +98,7 @@ std::string const help_page_advanced
     "          Choose the detection method(s) to be used. Value must be one of\n"
     "          (method name or number)\n"
     "          [0,cigar_string,1,split_read,2,read_pairs,3,read_depth]. Default:\n"
-    "          [cigar_string,split_read,read_pairs,read_depth].\n"
+    "          [cigar_string, split_read, read_pairs, read_depth].\n"
     "    -c, --clustering_method (clustering_methods)\n"
     "          Choose the clustering method to be used. Value must be one of\n"
     "          (method name or number)\n"
@@ -198,7 +204,9 @@ TEST_F(iGenVar_cli_test, no_options)
 // TODO (irallia): There is an open Issue, if we want to add the verbose option https://github.com/seqan/iGenVar/issues/20
 TEST_F(iGenVar_cli_test, test_verbose_option)
 {
-    cli_test_result result = execute_app("iGenVar", "-j", data(default_alignment_long_reads_file_path), "--verbose");
+    cli_test_result result = execute_app("iGenVar",
+                                         "-j", data(default_alignment_long_reads_file_path),
+                                         "--verbose");
     std::string const expected_err
     {
         "Detect junctions in long reads...\n"
@@ -628,7 +636,7 @@ TEST_F(iGenVar_cli_test, test_unknown_argument)
     std::string const expected_err
     {
         "[Error] You have chosen an invalid input value: 9. "
-        "Please use one of: [0,cigar_string,1,split_read,2,read_pairs,3,read_depth]\n"
+        "Please use one of: [0, cigar_string, 1, split_read, 2, read_pairs, 3, read_depth]\n"
     };
     EXPECT_EQ(result.exit_code, 65280);
     EXPECT_EQ(result.out, std::string{});

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -31,6 +31,8 @@ std::string const help_page_part_1
     "          Export the help page information. Value must be one of [html, man].\n"
     "    --version-check (bool)\n"
     "          Whether to check for the newest app version. Default: true.\n"
+    "\n"
+    "  Input / Output\n"
     "    -i, --input_short_reads (std::filesystem::path)\n"
     "          Input short read alignments in SAM or BAM format (Illumina).\n"
     "          Default: \"\". The input file must exist and read permissions must be\n"
@@ -54,8 +56,12 @@ std::string const help_page_part_1
     "          The path of the vcf output file. If no path is given, will output to\n"
     "          standard output. Default: \"\". Write permissions must be granted.\n"
     "          Valid file extensions are: [vcf].\n"
+    "\n"
+    "  VCF\n"
     "    -s, --vcf_sample_name (std::string)\n"
     "          Specify your sample name for the vcf header line. Default: MYSAMPLE.\n"
+    "\n"
+    "  Other parameters\n"
     "    -t, --threads (unsigned 64 bit integer)\n"
     "          Specify the number of decompression threads used for reading BAM\n"
     "          files. Default: 1.\n"
@@ -84,8 +90,22 @@ std::string const help_page_part_2
     "    For full copyright and/or warranty information see --copyright.\n"
 };
 
+std::string const help_page_not_advanced
+{
+    "\n"
+    "  Optional output\n"
+    "\n"
+    "  Methods\n"
+    "\n"
+    "  SV specifications\n"
+    "\n"
+    "  Clustering specifications\n"
+};
+
 std::string const help_page_advanced
 {
+    "\n"
+    "  Optional output\n"
     "    -a, --junctions (std::filesystem::path)\n"
     "          The path of the optional junction output file. If no path is given,\n"
     "          junctions will not be output. Default: \"\". Write permissions must be\n"
@@ -94,6 +114,8 @@ std::string const help_page_advanced
     "          The path of the optional cluster output file. If no path is given,\n"
     "          clusters will not be output. Default: \"\". Write permissions must be\n"
     "          granted.\n"
+    "\n"
+    "  Methods\n"
     "    -d, --method (List of detection_methods)\n"
     "          Choose the detection method(s) to be used. Value must be one of\n"
     "          (method name or number)\n"
@@ -109,6 +131,8 @@ std::string const help_page_advanced
     "          (method name or number)\n"
     "          [0,no_refinement,1,sViper_refinement_method,2,sVirl_refinement_method].\n"
     "          Default: no_refinement.\n"
+    "\n"
+    "  SV specifications\n"
     "    -k, --min_var_length (unsigned 64 bit integer)\n"
     "          Specify what should be the minimum length of your SVs to be\n"
     "          detected. This value needs to be non-negative. Default: 30.\n"
@@ -130,6 +154,8 @@ std::string const help_page_advanced
     "          Specify the minimum quality (amount of supporting reads) of a\n"
     "          structural variant to be reported in the vcf output file. This value\n"
     "          needs to be non-negative. Default: 5.\n"
+    "\n"
+    "  Clustering specifications\n"
     "    -p, --partition_max_distance (unsigned 64 bit integer)\n"
     "          Specify the maximum distance in bp between members of the same\n"
     "          partition.This value needs to be non-negative. Default: 50.\n"
@@ -231,7 +257,7 @@ TEST_F(iGenVar_cli_test, test_verbose_option)
 TEST_F(iGenVar_cli_test, help_page_argument)
 {
     cli_test_result result = execute_app("iGenVar", "--version-check", "false", "-h");
-    std::string const expected_res = help_page_part_1 + help_page_part_2;
+    std::string const expected_res = help_page_part_1 + help_page_not_advanced + help_page_part_2;
 
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected_res);

--- a/test/cli/iGenVar_cli_test.cpp
+++ b/test/cli/iGenVar_cli_test.cpp
@@ -205,6 +205,7 @@ TEST_F(iGenVar_cli_test, no_options)
 TEST_F(iGenVar_cli_test, test_verbose_option)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--verbose");
     std::string const expected_err
@@ -229,7 +230,7 @@ TEST_F(iGenVar_cli_test, test_verbose_option)
 
 TEST_F(iGenVar_cli_test, help_page_argument)
 {
-    cli_test_result result = execute_app("iGenVar", "-h");
+    cli_test_result result = execute_app("iGenVar", "--version-check", "false", "-h");
     std::string const expected_res = help_page_part_1 + help_page_part_2;
 
     EXPECT_EQ(result.exit_code, 0);
@@ -239,7 +240,7 @@ TEST_F(iGenVar_cli_test, help_page_argument)
 
 TEST_F(iGenVar_cli_test, advanced_help_page_argument)
 {
-    cli_test_result result = execute_app("iGenVar", "-hh");
+    cli_test_result result = execute_app("iGenVar", "--version-check", "false", "-hh");
     std::string const expected_res = help_page_part_1 + help_page_advanced + help_page_part_2;
 
     EXPECT_EQ(result.exit_code, 0);
@@ -251,7 +252,7 @@ TEST_F(iGenVar_cli_test, advanced_help_page_argument)
 
 TEST_F(iGenVar_cli_test, fail_no_input_file)
 {
-    cli_test_result result = execute_app("iGenVar", "--method cigar_string");
+    cli_test_result result = execute_app("iGenVar", "--version-check", "false", "--method cigar_string");
     std::string const expected_err
     {
         "[Error] You need to input at least one sam/bam file.\n"
@@ -265,6 +266,7 @@ TEST_F(iGenVar_cli_test, fail_no_input_file)
 TEST_F(iGenVar_cli_test, test_outfile)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j ", data(default_alignment_long_reads_file_path),
                                          "-o ", vcf_out_file_path);
     std::ifstream f;
@@ -280,6 +282,7 @@ TEST_F(iGenVar_cli_test, test_outfile)
 TEST_F(iGenVar_cli_test, test_intermediate_result_output)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j ", data(default_alignment_long_reads_file_path),
                                          "-a ", junctions_out_file_path,
                                          "-b ", clusters_out_file_path);
@@ -305,6 +308,7 @@ TEST_F(iGenVar_cli_test, test_intermediate_result_output)
 TEST_F(iGenVar_cli_test, test_genome_input)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-g", data(default_genome_file_path),
                                          "-i", data("single_end_mini_example.sam"));
     std::string const expected_err =
@@ -327,6 +331,7 @@ TEST_F(iGenVar_cli_test, test_genome_input)
 TEST_F(iGenVar_cli_test, fail_negative_min_var_length)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--min_var_length -30");
     std::string const expected_err
@@ -342,6 +347,7 @@ TEST_F(iGenVar_cli_test, fail_negative_min_var_length)
 TEST_F(iGenVar_cli_test, fail_negative_max_var_length)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--max_var_length -30");
     std::string const expected_err
@@ -357,6 +363,7 @@ TEST_F(iGenVar_cli_test, fail_negative_max_var_length)
 TEST_F(iGenVar_cli_test, fail_negative_max_tol_inserted_length)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--max_tol_inserted_length -30");
     std::string const expected_err
@@ -372,6 +379,7 @@ TEST_F(iGenVar_cli_test, fail_negative_max_tol_inserted_length)
 TEST_F(iGenVar_cli_test, fail_negative_max_overlap)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--max_overlap -30");
     std::string const expected_err
@@ -387,6 +395,7 @@ TEST_F(iGenVar_cli_test, fail_negative_max_overlap)
 TEST_F(iGenVar_cli_test, set_min_qual)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--min_qual 1");
     std::string const expected_err
@@ -407,6 +416,7 @@ TEST_F(iGenVar_cli_test, set_min_qual)
 TEST_F(iGenVar_cli_test, fail_negative_min_qual)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--min_qual -30");
     std::string const expected_err
@@ -423,6 +433,7 @@ TEST_F(iGenVar_cli_test, fail_negative_min_qual)
 TEST_F(iGenVar_cli_test, with_detection_method_arguments)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--method cigar_string --method split_read");
     std::string const expected_err
@@ -438,6 +449,7 @@ TEST_F(iGenVar_cli_test, with_detection_method_arguments)
 TEST_F(iGenVar_cli_test, with_detection_method_duplicate_arguments)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--method cigar_string --method cigar_string");
     std::string const expected_err
@@ -455,6 +467,7 @@ TEST_F(iGenVar_cli_test, with_detection_method_duplicate_arguments)
 TEST_F(iGenVar_cli_test, simple_clustering)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--clustering_method simple_clustering");
     std::string const expected_err
@@ -471,6 +484,7 @@ TEST_F(iGenVar_cli_test, simple_clustering)
 TEST_F(iGenVar_cli_test, hierarchical_clustering)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--clustering_method hierarchical_clustering");
     EXPECT_EQ(result.exit_code, 0);
@@ -481,6 +495,7 @@ TEST_F(iGenVar_cli_test, hierarchical_clustering)
 TEST_F(iGenVar_cli_test, fail_negative_hierarchical_clustering_cutoff)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--hierarchical_clustering_cutoff -30");
     std::string const expected_err
@@ -495,6 +510,7 @@ TEST_F(iGenVar_cli_test, fail_negative_hierarchical_clustering_cutoff)
 TEST_F(iGenVar_cli_test, self_balancing_binary_tree)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--clustering_method self_balancing_binary_tree");
     std::string const expected_err
@@ -512,6 +528,7 @@ TEST_F(iGenVar_cli_test, self_balancing_binary_tree)
 TEST_F(iGenVar_cli_test, candidate_selection_based_on_voting)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--clustering_method candidate_selection_based_on_voting");
     std::string const expected_err
@@ -531,6 +548,7 @@ TEST_F(iGenVar_cli_test, candidate_selection_based_on_voting)
 TEST_F(iGenVar_cli_test, no_refinement)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--refinement_method no_refinement");
     EXPECT_EQ(result.exit_code, 0);
@@ -541,6 +559,7 @@ TEST_F(iGenVar_cli_test, no_refinement)
 TEST_F(iGenVar_cli_test, sViper_refinement_method)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--refinement_method sViper_refinement_method");
     std::string const expected_err
@@ -557,6 +576,7 @@ TEST_F(iGenVar_cli_test, sViper_refinement_method)
 TEST_F(iGenVar_cli_test, sVirl_refinement_method)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--refinement_method sVirl_refinement_method");
     std::string const expected_err
@@ -575,6 +595,7 @@ TEST_F(iGenVar_cli_test, sVirl_refinement_method)
 TEST_F(iGenVar_cli_test, fail_unknown_option)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "-y 0");
 
@@ -590,7 +611,7 @@ TEST_F(iGenVar_cli_test, fail_unknown_option)
 
 TEST_F(iGenVar_cli_test, fail_missing_value)
 {
-    cli_test_result result = execute_app("iGenVar", "-i");
+    cli_test_result result = execute_app("iGenVar", "--version-check", "false", "-i");
     std::string const expected_err
     {
         "[Error] Missing value for option -i\n"
@@ -603,6 +624,7 @@ TEST_F(iGenVar_cli_test, fail_missing_value)
 TEST_F(iGenVar_cli_test, with_default_arguments)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j ", data(default_alignment_long_reads_file_path));
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out.erase(filedate_position_1, 19), expected_res_default); // erase the filedate
@@ -612,6 +634,7 @@ TEST_F(iGenVar_cli_test, with_default_arguments)
 TEST_F(iGenVar_cli_test, test_direct_methods_input)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--method cigar_string --method split_read "
                                          "--clustering_method 0 --refinement_method 0");
@@ -631,6 +654,7 @@ TEST_F(iGenVar_cli_test, test_direct_methods_input)
 TEST_F(iGenVar_cli_test, test_unknown_argument)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data(default_alignment_long_reads_file_path),
                                          "--method 9");
     std::string const expected_err
@@ -648,6 +672,7 @@ TEST_F(iGenVar_cli_test, test_unknown_argument)
 TEST_F(iGenVar_cli_test, dataset_paired_end_mini_example)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-i", data("paired_end_mini_example.sam"),
                                          "--method read_pairs");
 
@@ -707,6 +732,7 @@ TEST_F(iGenVar_cli_test, dataset_paired_end_mini_example)
 TEST_F(iGenVar_cli_test, dataset_single_end_mini_example)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-j", data("single_end_mini_example.sam"),
                                          "--verbose",
                                          "--method cigar_string --method split_read",
@@ -730,6 +756,7 @@ TEST_F(iGenVar_cli_test, dataset_single_end_mini_example)
 TEST_F(iGenVar_cli_test, dataset_short_and_long_read_mini_example)
 {
     cli_test_result result = execute_app("iGenVar",
+                                         "--version-check", "false",
                                          "-i", data("paired_end_mini_example.sam"),
                                          "-j", data("single_end_mini_example.sam"),
                                          "--verbose",


### PR DESCRIPTION
This PR updates SeqAn3 to use the sharg parser.
As the b.i.o. lib is using an older version of SeqAn3 I had to change the dependency stuff in the CmakeLists.

Wait for https://github.com/seqan/sharg-parser/pull/111