### PR TITLE
[INFRA] Update cmake version from 3.11.4 to 3.16.0

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.11.4
+  CMAKE_VERSION: 3.16.0
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  CMAKE_VERSION: 3.11.4
+  CMAKE_VERSION: 3.16.0
   SEQAN3_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -30,7 +30,7 @@ jobs:
             build: documentation
             build_threads: 2
             test_threads: 2
-            cmake: 3.11.4
+            cmake: 3.16.0
             doxygen: 1.9.3
             requires_toolchain: true
             requires_ccache: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 ## CUSTOMISE
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 # Find doxygen.
 find_package (Doxygen QUIET)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 # An object library (without main) to be used in multiple targets.
 add_library ("${PROJECT_NAME}_lib" STATIC modules/clustering/hierarchical_clustering_method.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 # Set directories for test output files, input data and binaries.
 file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output)

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 add_api_test (input_file_test.cpp)
 target_use_datasources (input_file_test FILES simulated.minimap2.hg19.coordsorted_cutoff.sam)

--- a/test/cli/CMakeLists.txt
+++ b/test/cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 add_cli_test(iGenVar_cli_test.cpp)
 add_dependencies (iGenVar_cli_test "iGenVar")

--- a/test/coverage/CMakeLists.txt
+++ b/test/coverage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.16)
 
 # Add a custom build type: Coverage
 

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.16)
 
 include (cmake/app_datasources.cmake)
 


### PR DESCRIPTION
For https://github.com/seqan/iGenVar/pull/218 we need to update the cmake (>=3.16) version.